### PR TITLE
feat: replace trufflehog with leaktk

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
@@ -67,13 +67,7 @@ spec:
             exit 0
         fi
 
-        trufflehog filesystem /workspace --only-verified --fail
-        EXIT_CODE=$?
-
-        if [ $EXIT_CODE -ne 0 ]; then
-            echo -e "[ERROR]: Found secrets in artifacts... Container artifacts will not be uploaded to OCI registry due to security reasons."
-            exit 1
-        fi
+        leaktk scan --kind Files --resource /workspace | leaktk-remove-files /workspace
 
         OCI_STORAGE_USERNAME="$(jq -r '."quay-username"' /usr/local/konflux-test-infra/oci-storage)"
         OCI_STORAGE_TOKEN="$(jq -r '."quay-token"' /usr/local/konflux-test-infra/oci-storage)"

--- a/dockerfiles/tool-box/Dockerfile
+++ b/dockerfiles/tool-box/Dockerfile
@@ -1,5 +1,7 @@
 # Builder
-FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:c9c0129bff8e94b9e23e9e4a1ebb5b932cccc24e064940a792bdc002da512d2a AS builder
+
+USER root
 
 # renovate: datasource=repology depName=homebrew/openshift-cli
 ARG OC_VERSION=4.15.9
@@ -17,15 +19,12 @@ ARG SHELLCHECK_VERSION=stable
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 ARG GOLANGCI_LINT_VERSION="v1.59.0"
 
-# utilities
-RUN yum -y install xz wget
+ARG LEAKTK_TAG="v0.0.13"
 
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION} && \
     cp bin/golangci-lint /usr/local/bin && \
     golangci-lint --version
-
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
 RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv && \
     cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ && \
@@ -59,6 +58,13 @@ RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VER
 RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/local/bin/ tkn && \
     tkn version
 
+ENV GOBIN=/usr/local/bin/
+RUN git clone --depth 1 --branch "${LEAKTK_TAG}" https://github.com/leaktk/scanner && cd scanner && make build && mv leaktk-scanner /usr/local/bin/
+
+# Removes files found in leaktk-scanner --kind Files scans
+# https://github.com/leaktk/hack/commit/b41569b3bbed867eabd15649f6650ae506c8cfc5
+RUN curl -LO https://raw.githubusercontent.com/leaktk/hack/b41569b3bbed867eabd15649f6650ae506c8cfc5/leaktk-remove-files && chmod +x leaktk-remove-files && mv leaktk-remove-files /usr/local/bin/
+
 # Runnable
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
 
@@ -76,7 +82,8 @@ COPY --from=builder /usr/local/bin/rosa /usr/local/bin/rosa
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/oras /usr/local/bin/oras
-COPY --from=builder /usr/local/bin/trufflehog /usr/local/bin/trufflehog
+COPY --from=builder /usr/local/bin/leaktk-scanner /usr/local/bin/leaktk-scanner
+COPY --from=builder /usr/local/bin/leaktk-remove-files /usr/local/bin/leaktk-remove-files
 COPY --from=builder /usr/local/bin/shellcheck /usr/local/bin/shellcheck
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin/golangci-lint
 COPY --from=builder /usr/local/bin/tkn /usr/local/bin/tkn


### PR DESCRIPTION
# JIRA
https://issues.redhat.com/browse/KFLUXDP-6

# To test this

```bash
# Build the image locally
➜ podman build -t leaktk-test . -f dockerfiles/tool-box/Dockerfile
# Run the command in built container image that will
# 1. Clone https://github.com/leaktk/fake-leaks repo
# 2. Execute command for scanning files fetched from "fake-leaks" repo
# 3. Results are piped into leaktk-remove-files script that removes files that were marked by leaktk tool as unsafe
# 4. Run `git status` to see which files were removed
➜ podman run -w /tmp leaktk-test bash -c "git clone https://github.com/leaktk/fake-leaks . && leaktk-scanner scan --kind Files --resource . | leaktk-remove-files . && git status"
# the output of `git status` will look like this
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    aws
        deleted:    containers/container-auth.1.json
        deleted:    containers/container-auth.2.json
        deleted:    containers/container-auth.3.json
        deleted:    dynatrace-token
        deleted:    foo.clientSecret
        deleted:    foo.p12
        deleted:    foo.password
...
```