### PR TITLE
feat: stepactions for secure push to OCI registry

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
@@ -67,13 +67,7 @@ spec:
             exit 0
         fi
 
-        trufflehog filesystem /workspace --only-verified --fail
-        EXIT_CODE=$?
-
-        if [ $EXIT_CODE -ne 0 ]; then
-            echo -e "[ERROR]: Found secrets in artifacts... Container artifacts will not be uploaded to OCI registry due to security reasons."
-            exit 1
-        fi
+        leaktk scan --kind Files --resource /workspace | leaktk-remove-files /workspace
 
         OCI_STORAGE_USERNAME="$(jq -r '."quay-username"' /usr/local/konflux-test-infra/oci-storage)"
         OCI_STORAGE_TOKEN="$(jq -r '."quay-token"' /usr/local/konflux-test-infra/oci-storage)"

--- a/dockerfiles/tool-box/Dockerfile
+++ b/dockerfiles/tool-box/Dockerfile
@@ -1,5 +1,7 @@
 # Builder
-FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:c9c0129bff8e94b9e23e9e4a1ebb5b932cccc24e064940a792bdc002da512d2a AS builder
+
+USER root
 
 # renovate: datasource=repology depName=homebrew/openshift-cli
 ARG OC_VERSION=4.15.9
@@ -17,15 +19,12 @@ ARG SHELLCHECK_VERSION=stable
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 ARG GOLANGCI_LINT_VERSION="v1.59.0"
 
-# utilities
-RUN yum -y install xz wget
+ARG LEAKTK_TAG="v0.0.13"
 
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION} && \
     cp bin/golangci-lint /usr/local/bin && \
     golangci-lint --version
-
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
 RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv && \
     cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ && \
@@ -59,6 +58,13 @@ RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VER
 RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/local/bin/ tkn && \
     tkn version
 
+ENV GOBIN=/usr/local/bin/
+RUN git clone --depth 1 --branch "${LEAKTK_TAG}" https://github.com/leaktk/scanner && cd scanner && make build && mv leaktk-scanner /usr/local/bin/
+
+# Removes files found in leaktk-scanner --kind Files scans
+# https://github.com/leaktk/hack/commit/b41569b3bbed867eabd15649f6650ae506c8cfc5
+RUN curl -LO https://raw.githubusercontent.com/leaktk/hack/b41569b3bbed867eabd15649f6650ae506c8cfc5/leaktk-remove-files && chmod +x leaktk-remove-files && mv leaktk-remove-files /usr/local/bin/
+
 # Runnable
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
 
@@ -76,7 +82,8 @@ COPY --from=builder /usr/local/bin/rosa /usr/local/bin/rosa
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/oras /usr/local/bin/oras
-COPY --from=builder /usr/local/bin/trufflehog /usr/local/bin/trufflehog
+COPY --from=builder /usr/local/bin/leaktk-scanner /usr/local/bin/leaktk-scanner
+COPY --from=builder /usr/local/bin/leaktk-remove-files /usr/local/bin/leaktk-remove-files
 COPY --from=builder /usr/local/bin/shellcheck /usr/local/bin/shellcheck
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin/golangci-lint
 COPY --from=builder /usr/local/bin/tkn /usr/local/bin/tkn

--- a/stepactions/fail-if-any-step-failed/0.1/README.md
+++ b/stepactions/fail-if-any-step-failed/0.1/README.md
@@ -1,3 +1,67 @@
 # fail-if-any-step-failed stepaction
 
-This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`
+This StepAction searches for exit codes (`/tekton/steps/<step-name>/exitCode`) in each step within the Task and fails if it detects that any `exitCode != "0"`
+
+It can be used in a scenario, when we don't want to fail the Task immediately in case of an error. In that case the error can be ignored using `onError: continue`
+field and then the Task failure is deferred to the end of the Task (using `fail-if-any-step-failed` stepaction).
+
+Such an example can be a Task used for running tests:
+
+
+```yaml
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test
+spec:
+  volumes:
+    - name: my-secrets-volume
+      secret:
+        secretName: my-secrets
+  steps:
+    - name: e2e-test
+      image: myimage
+      workingDir: /workspace/e2e-tests
+      # In case the test fails, we don't want to fail the TaskRun immediately,
+      # because we want to proceed with archiving the artifacts in a following step.
+      onError: continue
+      env:
+        - name: ARTIFACT_DIR
+          value: /workspace/artifact-dir
+
+      script: |
+        #!/bin/bash
+
+        ./run-tests | tee ${ARTIFACT_DIR}/e2e-tests.log
+    # Archive artifacts using this stepaction.
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace/artifact-dir
+        - name: oci-ref
+          value: quay.io/myorg/myrepo:container-tag
+        - name: credentials-volume-name
+          value: my-secrets-volume
+    # Now's the time to check whether some of the steps in this Task didn't fail.
+    # If it did, this stepaction will detect it and exit the step with the same non-zero exit code.
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+```

--- a/stepactions/fail-if-any-step-failed/0.1/README.md
+++ b/stepactions/fail-if-any-step-failed/0.1/README.md
@@ -1,0 +1,3 @@
+# fail-if-any-step-failed stepaction
+
+This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`

--- a/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+++ b/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: fail-if-any-step-failed
+spec:
+  description: |
+    This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  script: |
+    #!/bin/bash
+    set -e
+
+    # Loop through "exitCode" files containing exit codes of all executed steps within the Task
+    find -L "/tekton/steps/" -path "*/step-*/exitCode" | while read -r file; do
+        exitCode=$(<"$file")
+
+        # If some of the steps exited with non-zero code, exit the script with that code
+        if [ "$exitCode" != "0" ]; then
+            stepname=${file##*step-}
+            stepname=${stepname%%/*}
+            echo -e "[ERROR]: Step '$stepname' failed with exit code '$exitCode', which was previously ignored - exiting now"
+            exit $exitCode
+        fi
+    done
+
+    echo -e "[INFO]: Did not find any failed steps"

--- a/stepactions/secure-push-oci/0.1/README.md
+++ b/stepactions/secure-push-oci/0.1/README.md
@@ -1,0 +1,15 @@
+# secure-push-oci stepaction
+
+This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+Then it pushes the working directory contents to a specified OCI artifact repository tag.
+If the tag exists, it will update the existing content with the content of the working directory.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|workdir-path|Path to the workdir that is about to be uploaded to OCI artifact||true|
+|credentials-volume-name|Name of the volume that mounts the secret with "oci-storage-dockerconfigjson" key containing registry credentials in .dockerconfigjson format||true|
+|oci-ref|Full OCI artifact reference in a format "quay.io/org/repo:tag"||true|
+|oci-tag-expiration|OCI artifact tag expiration|1y|false|
+|always-pass|Even if execution of the stepaction's script fails, do not fail the step|"true"|false|

--- a/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+++ b/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
@@ -1,0 +1,96 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: secure-push-oci
+spec:
+  description: |
+    This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+    and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+    Then it pushes the working directory contents to a specified OCI artifact repository tag.
+    If the tag exists, it will update the existing content with the content of the working directory.
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  params:
+    - name: workdir-path
+      type: string
+      description: Path to the workdir that is about to be uploaded to OCI artifact
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
+    - name: credentials-volume-name
+      type: string
+      description: Name of the volume that mounts the secret with "oci-storage-dockerconfigjson" key containing registry credentials in .dockerconfigjson format
+    - name: oci-tag-expiration
+      type: string
+      default: 1y
+      description: OCI artifact tag expiration
+    - name: always-pass
+      type: string
+      default: "true"
+      description: Even if execution of the stepaction's script fails, do not fail the step
+  volumeMounts:
+  - name: $(params.credentials-volume-name)
+    mountPath: /home/tool-box/.docker/config.json
+    subPath: oci-storage-dockerconfigjson
+  workingDir: $(params.workdir-path)
+  env:
+    - name: OCI_ARTIFACT_REFERENCE
+      value: "$(params.oci-ref)"
+    - name: OCI_TAG_EXPIRATION
+      value: "$(params.oci-tag-expiration)"
+    - name: ALWAYS_PASS
+      value: "$(params.always-pass)"
+  script: |
+    #!/bin/bash
+    set -e
+
+    main() {
+      IMAGE_REF_REGEX='^quay\.io/[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)+:[a-zA-Z0-9._-]+$'
+
+      if [[ ! $OCI_ARTIFACT_REFERENCE =~ $IMAGE_REF_REGEX ]]; then
+          echo -e "[ERROR]: provided OCI artifact reference '$OCI_ARTIFACT_REFERENCE' is not in correct format 'quay.io/org/repo:tag'"
+          exit 1
+      fi
+
+      TAG="${OCI_ARTIFACT_REFERENCE##*:}"
+
+      TEMP_ANNOTATION_FILE="$(mktemp)"
+
+      # Fetch the manifest annotations for the container
+      MANIFESTS_ANNOTATIONS=$(oras manifest fetch "$OCI_ARTIFACT_REFERENCE" 2>> /dev/null | jq .annotations) || true
+
+      if [ "$MANIFESTS_ANNOTATIONS" == "" ]; then
+          # Create the annotations file, because it does not exist in the OCI artifact
+          echo -e "[INFO]: provided OCI artifact tag '$OCI_ARTIFACT_REFERENCE' does not exist - will create it"
+          jq -n --arg exp "$OCI_TAG_EXPIRATION" --arg title "Artifact storage for pipelinerun: $TAG" \
+              '{"$manifest": {"quay.expires-after": $exp, "org.opencontainers.image.title": $title}}' > "${TEMP_ANNOTATION_FILE}"
+      else
+          echo -e "[INFO]: going to update existing content in '$OCI_ARTIFACT_REFERENCE'"
+          # Keep the existing annotations file for further use
+          jq -n --argjson manifest "$MANIFESTS_ANNOTATIONS" '{ "$manifest": $manifest }' > "${TEMP_ANNOTATION_FILE}"
+          oras pull "$OCI_ARTIFACT_REFERENCE"
+      fi
+
+      # Scan the working directory using leaktk-scanner and remove problematic files
+      log_filename="leaktk-scan-$(date +%s).log"
+      leaktk-scanner scan --kind Files --resource . 2>> $log_filename | leaktk-remove-files . &>> $log_filename
+
+      # Push the content to remote artifact storage
+      attempt=1
+      while ! oras push "$OCI_ARTIFACT_REFERENCE" --annotation-file "${TEMP_ANNOTATION_FILE}" ./:application/vnd.acme.rocket.docs.layer.v1+tar; do
+          if [[ $attempt -ge 5 ]]; then
+              echo -e "[ERROR]: oras push failed after $attempt attempts."
+              rm -f "${TEMP_ANNOTATION_FILE}"
+              exit 1
+          fi
+          echo -e "[WARNING]: oras push failed (attempt $attempt). Retrying in 5 seconds..."
+          sleep 5
+          ((attempt++))
+      done
+    }
+
+    if [ "$ALWAYS_PASS" == "true" ]; then
+      main || true
+    else
+      main
+    fi
+    


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-6

### Description
This PR introduces 2 new stepactions:
* `secure-push-oci`, that scans the content of the specified directory, removes files that contain leaked information and pushes the directory content to the new/existing OCI artifact in quay.io, including the log from the leaktk CLI scan
* `fail-if-any-step-failed` - which purpose is to exit with non-zero code, if any of the steps executed as a part of the tekton Task exited with non-zero code. This is useful in Tasks, where we want to save artifacts that were produced by a step, where the error was purposely ignored (using `error: continue` field), but still want to fail the Task in the end, to give the user the correct job results

### Additional comments
* it also contains a commit from [this PR](https://github.com/konflux-ci/tekton-integration-catalog/pull/73), that was [reverted](https://github.com/konflux-ci/tekton-integration-catalog/pull/75) after merge due to missing updates in `quay.io/konflux-qe-incubator/konflux-qe-tools:latest` image - it was updated and now it is save to merge it


### Verification
* fully tested in [this PR](https://github.com/konflux-ci/e2e-tests/pull/1475), artifacts from that test run are available [here](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/e2e-tests/2024-12-10_11-34-04+konflux-e2e-r7gpr/)