### PR TITLE
feat: collect log from provisioning rosa HCP

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
@@ -67,7 +67,13 @@ spec:
             exit 0
         fi
 
-        leaktk scan --kind Files --resource /workspace | leaktk-remove-files /workspace
+        trufflehog filesystem /workspace --only-verified --fail
+        EXIT_CODE=$?
+
+        if [ $EXIT_CODE -ne 0 ]; then
+            echo -e "[ERROR]: Found secrets in artifacts... Container artifacts will not be uploaded to OCI registry due to security reasons."
+            exit 1
+        fi
 
         OCI_STORAGE_USERNAME="$(jq -r '."quay-username"' /usr/local/konflux-test-infra/oci-storage)"
         OCI_STORAGE_TOKEN="$(jq -r '."quay-token"' /usr/local/konflux-test-infra/oci-storage)"

--- a/dockerfiles/tool-box/Dockerfile
+++ b/dockerfiles/tool-box/Dockerfile
@@ -1,7 +1,5 @@
 # Builder
-FROM registry.redhat.io/ubi9/go-toolset@sha256:c9c0129bff8e94b9e23e9e4a1ebb5b932cccc24e064940a792bdc002da512d2a AS builder
-
-USER root
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072 AS builder
 
 # renovate: datasource=repology depName=homebrew/openshift-cli
 ARG OC_VERSION=4.15.9
@@ -19,12 +17,15 @@ ARG SHELLCHECK_VERSION=stable
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 ARG GOLANGCI_LINT_VERSION="v1.59.0"
 
-ARG LEAKTK_TAG="v0.0.13"
+# utilities
+RUN yum -y install xz wget
 
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION} && \
     cp bin/golangci-lint /usr/local/bin && \
     golangci-lint --version
+
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
 RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv && \
     cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ && \
@@ -58,13 +59,6 @@ RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VER
 RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/local/bin/ tkn && \
     tkn version
 
-ENV GOBIN=/usr/local/bin/
-RUN git clone --depth 1 --branch "${LEAKTK_TAG}" https://github.com/leaktk/scanner && cd scanner && make build && mv leaktk-scanner /usr/local/bin/
-
-# Removes files found in leaktk-scanner --kind Files scans
-# https://github.com/leaktk/hack/commit/b41569b3bbed867eabd15649f6650ae506c8cfc5
-RUN curl -LO https://raw.githubusercontent.com/leaktk/hack/b41569b3bbed867eabd15649f6650ae506c8cfc5/leaktk-remove-files && chmod +x leaktk-remove-files && mv leaktk-remove-files /usr/local/bin/
-
 # Runnable
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1610@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
 
@@ -82,8 +76,7 @@ COPY --from=builder /usr/local/bin/rosa /usr/local/bin/rosa
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/oras /usr/local/bin/oras
-COPY --from=builder /usr/local/bin/leaktk-scanner /usr/local/bin/leaktk-scanner
-COPY --from=builder /usr/local/bin/leaktk-remove-files /usr/local/bin/leaktk-remove-files
+COPY --from=builder /usr/local/bin/trufflehog /usr/local/bin/trufflehog
 COPY --from=builder /usr/local/bin/shellcheck /usr/local/bin/shellcheck
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin/golangci-lint
 COPY --from=builder /usr/local/bin/tkn /usr/local/bin/tkn

--- a/stepactions/fail-if-any-step-failed/0.1/README.md
+++ b/stepactions/fail-if-any-step-failed/0.1/README.md
@@ -1,0 +1,3 @@
+# fail-if-any-step-failed stepaction
+
+This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`

--- a/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+++ b/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: fail-if-any-step-failed
+spec:
+  description: |
+    This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  script: |
+    #!/bin/bash
+    set -e
+
+    # Loop through "exitCode" files containing exit codes of all executed steps within the Task
+    find -L "/tekton/steps/" -path "*/step-*/exitCode" | while read -r file; do
+        exitCode=$(<"$file")
+
+        # If some of the steps exited with non-zero code, exit the script with that code
+        if [ "$exitCode" != "0" ]; then
+            stepname=${file##*step-}
+            stepname=${stepname%%/*}
+            echo -e "[ERROR]: Step '$stepname' failed with exit code '$exitCode', which was previously ignored - exiting now"
+            exit $exitCode
+        fi
+    done
+
+    echo -e "[INFO]: Did not find any failed steps"

--- a/stepactions/secure-push-oci/0.1/README.md
+++ b/stepactions/secure-push-oci/0.1/README.md
@@ -1,0 +1,15 @@
+# secure-push-oci stepaction
+
+This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+Then it pushes the working directory contents to a specified OCI artifact repository tag.
+If the tag exists, it will update the existing content with the content of the working directory.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|workdir-path|Path to the workdir that is about to be uploaded to OCI artifact||true|
+|credentials-volume-name|Name of the volume that mounts the secret with "oci-storage-dockerconfigjson" key containing registry credentials in .dockerconfigjson format||true|
+|oci-ref|Full OCI artifact reference in a format "quay.io/org/repo:tag"||true|
+|oci-tag-expiration|OCI artifact tag expiration|1y|false|
+|always-pass|Even if execution of the stepaction's script fails, do not fail the step|"true"|false|

--- a/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+++ b/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
@@ -1,0 +1,96 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: secure-push-oci
+spec:
+  description: |
+    This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+    and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+    Then it pushes the working directory contents to a specified OCI artifact repository tag.
+    If the tag exists, it will update the existing content with the content of the working directory.
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  params:
+    - name: workdir-path
+      type: string
+      description: Path to the workdir that is about to be uploaded to OCI artifact
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
+    - name: credentials-volume-name
+      type: string
+      description: Name of the volume that mounts the secret with "oci-storage-dockerconfigjson" key containing registry credentials in .dockerconfigjson format
+    - name: oci-tag-expiration
+      type: string
+      default: 1y
+      description: OCI artifact tag expiration
+    - name: always-pass
+      type: string
+      default: "true"
+      description: Even if execution of the stepaction's script fails, do not fail the step
+  volumeMounts:
+  - name: $(params.credentials-volume-name)
+    mountPath: /home/tool-box/.docker/config.json
+    subPath: oci-storage-dockerconfigjson
+  workingDir: $(params.workdir-path)
+  env:
+    - name: OCI_ARTIFACT_REFERENCE
+      value: "$(params.oci-ref)"
+    - name: OCI_TAG_EXPIRATION
+      value: "$(params.oci-tag-expiration)"
+    - name: ALWAYS_PASS
+      value: "$(params.always-pass)"
+  script: |
+    #!/bin/bash
+    set -e
+
+    main() {
+      IMAGE_REF_REGEX='^quay\.io/[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)+:[a-zA-Z0-9._-]+$'
+
+      if [[ ! $OCI_ARTIFACT_REFERENCE =~ $IMAGE_REF_REGEX ]]; then
+          echo -e "[ERROR]: provided OCI artifact reference '$OCI_ARTIFACT_REFERENCE' is not in correct format 'quay.io/org/repo:tag'"
+          exit 1
+      fi
+
+      TAG="${OCI_ARTIFACT_REFERENCE##*:}"
+
+      TEMP_ANNOTATION_FILE="$(mktemp)"
+
+      # Fetch the manifest annotations for the container
+      MANIFESTS_ANNOTATIONS=$(oras manifest fetch "$OCI_ARTIFACT_REFERENCE" 2>> /dev/null | jq .annotations) || true
+
+      if [ "$MANIFESTS_ANNOTATIONS" == "" ]; then
+          # Create the annotations file, because it does not exist in the OCI artifact
+          echo -e "[INFO]: provided OCI artifact tag '$OCI_ARTIFACT_REFERENCE' does not exist - will create it"
+          jq -n --arg exp "$OCI_TAG_EXPIRATION" --arg title "Artifact storage for pipelinerun: $TAG" \
+              '{"$manifest": {"quay.expires-after": $exp, "org.opencontainers.image.title": $title}}' > "${TEMP_ANNOTATION_FILE}"
+      else
+          echo -e "[INFO]: going to update existing content in '$OCI_ARTIFACT_REFERENCE'"
+          # Keep the existing annotations file for further use
+          jq -n --argjson manifest "$MANIFESTS_ANNOTATIONS" '{ "$manifest": $manifest }' > "${TEMP_ANNOTATION_FILE}"
+          oras pull "$OCI_ARTIFACT_REFERENCE"
+      fi
+
+      # Scan the working directory using leaktk-scanner and remove problematic files
+      log_filename="leaktk-scan-$(date +%s).log"
+      leaktk-scanner scan --kind Files --resource . 2>> $log_filename | leaktk-remove-files . &>> $log_filename
+
+      # Push the content to remote artifact storage
+      attempt=1
+      while ! oras push "$OCI_ARTIFACT_REFERENCE" --annotation-file "${TEMP_ANNOTATION_FILE}" ./:application/vnd.acme.rocket.docs.layer.v1+tar; do
+          if [[ $attempt -ge 5 ]]; then
+              echo -e "[ERROR]: oras push failed after $attempt attempts."
+              rm -f "${TEMP_ANNOTATION_FILE}"
+              exit 1
+          fi
+          echo -e "[WARNING]: oras push failed (attempt $attempt). Retrying in 5 seconds..."
+          sleep 5
+          ((attempt++))
+      done
+    }
+
+    if [ "$ALWAYS_PASS" == "true" ]; then
+      main || true
+    else
+      main
+    fi
+    

--- a/tasks/rosa/hosted-cp/README.md
+++ b/tasks/rosa/hosted-cp/README.md
@@ -1,0 +1,3 @@
+# Tekton Task: Rosa HCP
+
+Please read/update [rosa-hcp tasks docs](../../../docs/qe-available-tasks/rosa.md) from docs folder.

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
@@ -1,0 +1,202 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-artifacts-deprovision-rosa
+spec:
+  description: |
+    This Tekton Task handles the collection of test artifacts and deprovisions the OpenShift cluster. The task performs the following steps:
+    1. **Collect Artifacts**: Gathers artifacts if the pipeline did not succeed.
+    2. **Inspect and Upload Artifacts**: Checks for sensitive information in the artifacts and uploads them to the OCI container registry.
+    3. **Deprovision ROSA Cluster**: Deletes the OpenShift cluster if specified.
+    4. **Remove Tags from Subnets**: Cleans up tags from AWS subnets associated with the cluster.
+    5. **Remove Load Balancers**: Deletes any associated AWS load balancers.
+  params:
+    - name: test-name
+      type: string
+      description: The name of the test being executed.
+    - name: ocp-login-command
+      type: string
+      description: Command to log in to the OpenShift cluster.
+    - name: oci-container
+      type: string
+      description: The ORAS container registry URI where artifacts will be stored.
+    - name: cluster-name
+      type: string
+      description: The name of the OpenShift cluster that is to be deleted.
+    - name: konflux-test-infra-secret
+      type: string
+      description: The name of the secret containing credentials for testing infrastructure.
+    - name: cloud-credential-key
+      type: string
+      description: The key within the konflux-test-infra secret where AWS ROSA configuration details are stored.
+    - name: pipeline-aggregate-status
+      type: string
+      description: The status of the pipeline (e.g., Succeeded, Failed, Completed, None).
+      default: None
+  volumes:
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: konflux-test-infra
+  steps:
+    - name: collect-artifacts
+      workingDir: /workspace/cluster-artifacts
+      onError: continue
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      script: |
+        #!/bin/sh
+        $(params.ocp-login-command)
+
+        curl -sSL https://raw.githubusercontent.com/konflux-ci/konflux-qe-definitions/main/scripts/gather-extra.sh | bash
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace
+        - name: oci-ref
+          value: $(params.oci-container)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+    - name: deprovision-rosa
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      script: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        export CLUSTER_NAME REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY ROSA_TOKEN
+
+        CLUSTER_NAME=$(params.cluster-name)
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        config_aws_creds() {
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+            aws configure set region "$REGION"
+        }
+
+        if [[ -n "$CLUSTER_NAME"  ]]; then
+            echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Started to destroy cluster [$CLUSTER_NAME]..."
+
+            printf "INFO: Logging in to your Red Hat account...\n"
+            config_aws_creds
+            rosa login --token="$ROSA_TOKEN"
+
+            # Trigger the deletion of the cluster without waiting for it to be completely deleted
+            rosa delete cluster --region "$REGION" --cluster="$CLUSTER_NAME" -y
+
+        else
+            echo "INFO: No OCP cluster needs to be destroyed."
+        fi
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Done"
+    - name: remove-tag-from-subnets
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      script: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        CLUSTER_NAME=$(params.cluster-name)
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        SUBNET_IDS=$(jq -r '.aws["rosa-hcp"]["subnets-ids"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+        aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+        aws configure set region "$REGION"
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Started to remove tags of cluster [$CLUSTER_NAME]..."
+
+        printf "INFO: Logging in to your Red Hat account...\n"
+        rosa login --token="$ROSA_TOKEN"
+
+        if [[ -n "$CLUSTER_NAME"  ]]; then
+            cluster_id=$(rosa --region "$REGION"  describe cluster --cluster="$CLUSTER_NAME" -o json | jq -r .id)
+            echo "INFO: Cluster ID: $cluster_id"
+
+            echo "INFO: Removing tag from subnets [$SUBNET_IDS]..."
+            new_subnet_ids="${SUBNET_IDS//,/ }"
+            aws --region "$REGION" ec2 delete-tags --resources $new_subnet_ids --tags Key="kubernetes.io/cluster/${cluster_id}"
+
+            echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Done"
+        else
+          echo "INFO: No OCP cluster tag needs to be removed."
+        fi
+    - name: remove-load-balancers
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      script: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        export CLUSTER_NAME REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+        CLUSTER_NAME=$(params.cluster-name)
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+        aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+        aws configure set region "$REGION"
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Started to remove load balancers of cluster [$CLUSTER_NAME]..."
+
+        ELB_TAG_KEY="api.openshift.com/name"
+        ELB_TAG_VALUE=$(params.cluster-name)
+
+        # Get all load balancer ARNs
+        all_arns=$(aws elbv2 describe-load-balancers --query 'LoadBalancers[*].LoadBalancerArn' --output text)
+
+        # Process the ARNs in batches of 20 to avoid errors like:
+        # An error occurred (ValidationError) when calling the DescribeTags operation:
+        # Cannot have more than 20 resources described
+
+        batch_size=20
+        arns_to_delete=()
+
+        for arn in $all_arns; do
+            arns_to_delete+=($arn)
+            
+            if [ ${#arns_to_delete[@]} -eq $batch_size ]; then
+                aws elbv2 describe-tags --resource-arns ${arns_to_delete[@]} \
+                --query "TagDescriptions[?Tags[?Key=='$ELB_TAG_KEY' && Value=='$ELB_TAG_VALUE']].ResourceArn" --output text | while read matched_arn; do
+                    echo "Deleting load balancer with ARN: $matched_arn"
+                    aws elbv2 delete-load-balancer --load-balancer-arn $matched_arn
+                done
+                arns_to_delete=()
+            fi
+        done

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
@@ -1,0 +1,214 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rosa-hcp-provision
+spec:
+  description: |
+    The `rosa-hcp-provision` task automates the creation and provisioning of an ephemeral OpenShift cluster using Red Hat OpenShift on AWS (ROSA) with Hosted Control Planes (HCP).
+    The task takes several parameters, including the OpenShift version, AWS machine type, and cluster name, to configure and deploy the cluster on AWS.
+    It uses credentials stored in a Kubernetes secret for authentication and configuration of AWS and ROSA.
+    Once the cluster is provisioned, the task outputs a login command to access the newly created cluster, which can be used in subsequent pipeline steps.
+  results:
+    - name: ocp-login-command
+      description: Command to log in to the newly ephemeral OpenShift cluster.
+  params:
+    - name: ocp-version
+      type: string
+      description: The version of the OpenShift Container Platform (OCP) to deploy. This will be used to fetch the corresponding HCP version for deployment.
+    - name: cluster-name
+      type: string
+      description: The unique name of the OpenShift cluster to be created.
+    - name: machine-type
+      type: string
+      description: The AWS EC2 instance type to be used for the worker nodes of the OpenShift cluster (e.g., m5.xlarge).
+    - name: replicas
+      type: string
+      description: The number of worker nodes to provision in the cluster. Defaults to 3 worker nodes.
+      default: '3'
+    - name: konflux-test-infra-secret
+      type: string
+      description: The name of the Kubernetes secret that contains AWS and ROSA configuration credentials needed for cluster provisioning.
+    - name: cloud-credential-key
+      type: string
+      description: The key within the secret where AWS ROSA configurations (e.g., credentials, roles) are stored.
+    - name: oci-container
+      type: string
+      description: The ORAS container registry URI where artifacts will be stored.
+  volumes:
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: "$(params.konflux-test-infra-secret)"
+  steps:
+    - name: provision
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      workingDir: /workspace/cluster-provision
+      env:
+        - name: CLUSTER_NAME
+          value: "$(params.cluster-name)"
+        - name: OCP_VERSION
+          value: "$(params.ocp-version)"
+        - name: MACHINE_TYPE
+          value: "$(params.machine-type)"
+      script: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        export ROSA_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BILLING_ACCOUNT_ID AWS_OIDC_CONFIG_ID OPERATOR_ROLES_PREFIX \
+              SUBNET_IDS INSTALL_ROLE_ARN SUPPORT_ROLE_ARN WORKER_ROLE_ARN REGION
+
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        BILLING_ACCOUNT_ID=$(jq -r '.aws["aws-account-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_OIDC_CONFIG_ID=$(jq -r '.aws["rosa-hcp"]["aws-oidc-config-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        OPERATOR_ROLES_PREFIX=$(jq -r '.aws["rosa-hcp"]["operator-roles-prefix"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        SUBNET_IDS=$(jq -r '.aws["rosa-hcp"]["subnets-ids"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        INSTALL_ROLE_ARN=$(jq -r '.aws["rosa-hcp"]["install-role-arn"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        SUPPORT_ROLE_ARN=$(jq -r '.aws["rosa-hcp"]["support-role-arn"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        WORKER_ROLE_ARN=$(jq -r '.aws["rosa-hcp"]["worker-role-arn"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        main() {
+          config_aws_creds() {
+              printf "INFO: Configure AWS Credentials...\n" 
+              aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+              aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+              aws configure set region "$REGION"
+          }
+
+          print_debug_info() {
+              printf "INFO: Print debug info......\n" 
+              rosa --region "$REGION" describe cluster --cluster="$CLUSTER_NAME"
+          }
+
+          # Even the cluster is shown ready on ocm side, and the cluster operators are available, some of the cluster operators are still progressing.
+          check_clusteroperators() {
+              local STATUS_LOG="co_status.log"
+              local max_attempts=10
+              local attempt
+              echo "[INFO] Checking cluster operators' status..."
+              # retrying to get clusteroperator. Makes sense in case master nodes are not ready
+              for attempt in $(seq 1 $max_attempts); do
+                  echo "[INFO] Attempt $attempt/$max_attempts"
+                  if kubectl get clusteroperators -A > "$STATUS_LOG" 2>&1; then
+                      cat "$STATUS_LOG"
+                      echo "[INFO] Cluster operators are accessible."
+                      break
+                  fi
+                  echo "[INFO] Attempt $attempt failed, retrying in 10 seconds..."
+                  sleep 10
+              done
+              if [ $attempt -eq $max_attempts ]; then
+                  echo "[ERROR] All attempts to access cluster operators failed. Check $STATUS_LOG for details."
+                  cat "$STATUS_LOG"
+                  return 1
+              fi
+              echo "[INFO] Waiting for cluster operators to be in 'Progressing=false' state..."
+              kubectl wait clusteroperators --all --for=condition=Progressing=false --timeout=60m > "$STATUS_LOG" 2>&1
+              cat "$STATUS_LOG"
+          }
+
+          get_hcp_full_version() {
+              rosa_output=$(rosa list version --channel-group stable --region "$REGION" --hosted-cp -o json)
+              raw_id=$(echo "$rosa_output" | jq -r "[.[].raw_id | select(startswith(\"$OCP_VERSION\"))] | max")
+              HCP_FULL_VERSION="$raw_id"
+              if [ -z "$HCP_FULL_VERSION" ]; then
+                  echo "Failed to get the HCP full version of $OCP_VERSION" >&2
+                  exit 1
+              fi
+          }
+
+          deploy_cluster() {
+              printf "INFO: Log in to your Red Hat account...\n" 
+              config_aws_creds
+              rosa login --token="$ROSA_TOKEN"
+
+              printf "INFO: Create ROSA with HCP cluster...\n" 
+              get_hcp_full_version
+              rosa create cluster --cluster-name "$CLUSTER_NAME" \
+                  --sts --mode=auto --oidc-config-id "$AWS_OIDC_CONFIG_ID" \
+                  --operator-roles-prefix "$OPERATOR_ROLES_PREFIX" --region "$REGION" --version "$HCP_FULL_VERSION" \
+                  --role-arn "$INSTALL_ROLE_ARN" \
+                  --support-role-arn "$SUPPORT_ROLE_ARN" \
+                  --worker-iam-role "$WORKER_ROLE_ARN" \
+                  --compute-machine-type "$MACHINE_TYPE" \
+                  --subnet-ids="$SUBNET_IDS" \
+                  --billing-account "$BILLING_ACCOUNT_ID" \
+                  --replicas $(params.replicas) \
+                  --tags konflux-ci:true,creation-date:$(date -u +"%Y-%m-%d"),cluster-type:rosa-hcp \
+                  --hosted-cp -y
+
+              printf "INFO: Track the progress of the cluster creation...\n" 
+              rosa logs install --cluster="$CLUSTER_NAME" --region "$REGION" --watch
+
+              printf "INFO: ROSA with HCP cluster is ready, create a cluster admin account for accessing the cluster\n" 
+              admin_output="$(rosa create admin --region "$REGION" --cluster="$CLUSTER_NAME")"
+
+              # Get the admin account credentials and API server URL
+              admin_user="$(echo "$admin_output" | grep -oP '(?<=--username ).*(?= --password)')"
+              admin_pass="$(echo "$admin_output" | grep -oP '(?<=--password ).*')"
+              api_url="$(echo "$admin_output" | grep -oP '(?<=oc login ).*(?= --username)')"
+
+              printf "INFO: Storing login command...\n"
+              echo "oc login $api_url --username $admin_user --password $admin_pass" > $(results.ocp-login-command.path)
+
+              # Use the admin account to login to the cluster in a loop until the account is active.
+              printf "INFO: Check if it's able to login to OCP cluster...\n"
+              max_retries=10
+              retries=0
+              
+              while ! oc login "$api_url" --username "$admin_user" --password "$admin_pass" >/dev/null 2>&1; do
+                  if [ "$retries" -eq "$max_retries" ]; then
+                      echo "ERROR: Failed to login the cluster." >&2
+                      print_debug_info
+                      exit 1
+                  fi
+                  sleep 60
+                  retries=$((retries + 1))
+                  echo "Retried $retries times..."
+              done
+
+              #Workaround: Check if apiserver is ready by calling kubectl get nodes
+              printf "INFO: Check if apiserver is ready...\n"
+              if ! timeout 300s bash -c "while ! kubectl get nodes >/dev/null 2>/dev/null; do printf '.'; sleep 10; done"; then
+                  echo "ERROR: API server is not ready" >&2
+                  exit 1
+              fi
+              check_clusteroperators
+          }
+
+          deploy_cluster
+        }
+        main 2>&1 | tee cluster-provision.log
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace/cluster-provision
+        - name: oci-ref
+          value: $(params.oci-container)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-55

### Description
This PR depends on https://github.com/konflux-ci/tekton-integration-catalog/pull/76 being merged first

It adds 
* new version of `rosa-hcp-provision` task, that uses `secure-push-oci` stepaction to push log from cluster provision to OCI storage
* new version of `rosa-hcp-provision` task, that replaces [this task](https://github.com/konflux-ci/tekton-integration-catalog/blob/8ee3c6097915fd56928a915cf2d6d857064814d9/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml#L55-L104) with `secure-push-oci` stepaction and adds `onError: continue` field to the rest of deprovision steps, to make sure the error in deprovisioning doesn't fail the whole PipelineRun (if it was successful till that point)