### PR TITLE
Fix analyze-test-results path

### DIFF
--- a/common/tasks/pull-request-comment/0.2/pull-request-comment.yaml
+++ b/common/tasks/pull-request-comment/0.2/pull-request-comment.yaml
@@ -53,7 +53,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/stepactions/analyze-test-results/0.1/analyze-test-results.yaml
+            value: stepactions/analyze-test-results/0.1/analyze-test-results.yaml
       params:
         - name: workspace-path
           value: /workspace


### PR DESCRIPTION
pull-request-status-message task is currently failing with 
```
error requesting remote resource: error getting "Git" "rhtap-shared-team-tenant/git-9e39917f050fbbfe4cb4f9bf932ded92": error opening file "common/stepactions/analyze-test-results/0.1/analyze-test-results.yaml": file does not exist
```
This should hopefully fix it.