### PR TITLE
fix: add target-repo-branch to test-metadata Task

### DIFF
--- a/common/tasks/test-metadata/0.1/test-metadata.yaml
+++ b/common/tasks/test-metadata/0.1/test-metadata.yaml
@@ -33,6 +33,8 @@ spec:
       description: Will show the source from where a Pull Request was opened. Can be from a fork or upstream.
     - name: source-repo-branch
       description: Get the branch from the fork or upstream repo where the pipeline is executed.
+    - name: target-repo-branch
+      description: The target branch value from the Pull Request or the current branch value in case of push event. 
     - name: component-name
       description: The name of the component that is being executed from Konflux.
   params:
@@ -76,6 +78,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-branch']
+        # This value refers to the target branch value in 'pull-request' events and branch value in 'push' events.
+        # E.g. for push event to 'main' branch this will have the value 'main'. For PR event that targets 'main' branch, this will be also 'main'.
+        - name: TARGET_REPO_BRANCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/branch']
       script: |
         #!/bin/bash
 
@@ -104,7 +112,8 @@ spec:
                 "commit_sha": "$GIT_REVISION",
                 "event_type": "$EVENT_TYPE",
                 "source_repo_url": "$SOURCE_REPO_URL",
-                "source_repo_branch": "$SOURCE_REPO_BRANCH"
+                "source_repo_branch": "$SOURCE_REPO_BRANCH",
+                "target_repo_branch": "$TARGET_REPO_BRANCH"
             }
         }
         EOF
@@ -127,6 +136,7 @@ spec:
         echo "  COMPONENT_CONTAINER_IMAGE: $COMPONENT_CONTAINER_IMAGE"
         echo "  SOURCE_REPO_URL: $SOURCE_REPO_URL"
         echo "  SOURCE_REPO_BRANCH: $SOURCE_REPO_BRANCH"
+        echo "  TARGET_REPO_BRANCH: $TARGET_REPO_BRANCH"
 
         # Write each environment variable to its respective result file
         echo -n "$EVENT_TYPE" > $(results.test-event-type.path)
@@ -140,4 +150,5 @@ spec:
         echo -n "$JOB_SPEC" > $(results.job-spec.path)
         echo -n "$SOURCE_REPO_URL" > $(results.source-repo-url.path)
         echo -n "$SOURCE_REPO_BRANCH" > $(results.source-repo-branch.path)
+        echo -n "$TARGET_REPO_BRANCH" > $(results.target-repo-branch.path)
         echo -n "$KONFLUX_COMPONENT_NAME" > $(results.component-name.path)

--- a/common/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/common/tasks/test-metadata/0.2/test-metadata.yaml
@@ -48,6 +48,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-branch']
+        # This value refers to the target branch value in 'pull-request' events and branch value in 'push' events.
+        # E.g. for push event to 'main' branch this will have the value 'main'. For PR event that targets 'main' branch, this will be also 'main'.
+        - name: TARGET_REPO_BRANCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/branch']
       script: |
         #!/bin/bash
 
@@ -82,6 +88,7 @@ spec:
                 "source_repo_url": "$SOURCE_REPO_URL",
                 "source_repo_org": "$SOURCE_REPO_ORG",
                 "source_repo_branch": "$SOURCE_REPO_BRANCH",
+                "target_repo_branch": "$TARGET_REPO_BRANCH",
                 "url": "$GIT_URL",
                 "revision": "$GIT_REVISION"
             }

--- a/docs/qe-available-tasks/test-metadata/0.1-test-metadata.md
+++ b/docs/qe-available-tasks/test-metadata/0.1-test-metadata.md
@@ -58,7 +58,10 @@ The task produces the following results:
 9. **pull-request-author**: The GitHub author of the pull request event.
     - **Description**: This result identifies the author of the pull request, providing context about who made the changes.
 
-10. **job-spec**: The konflux CI job spec metadata generated.
+10. **target-repo-branch**: The Git branch which the test pipeline is targeting. This can be from an original repository the Pull Request or Push event is targeting.
+    - **Description**: This result identifies the target repository branch.
+
+11. **job-spec**: The konflux CI job spec metadata generated.
     - **Description**: This result contains a JSON object with comprehensive details about the job specification, including container image, component name, git information, and event type. It encapsulates all the relevant metadata for the CI job in a structured format, aiding in documentation and analysis.
 
 ## Usage

--- a/docs/qe-available-tasks/test-metadata/0.2-test-metadata.md
+++ b/docs/qe-available-tasks/test-metadata/0.2-test-metadata.md
@@ -73,6 +73,9 @@ The task produces the following results:
     - **git.source_repo_branch**: The Git branch from which the test pipeline is originating. This can be from a fork or the original repository.
       - **Description**: This result identifies the source repository branch, helping to trace back the origin of the code being tested. It is useful for verifying the source of the changes and ensuring they come from a trusted repository.
 
+    - **git.target_repo_branch**: The Git branch which the test pipeline is targeting. This can be from an original repository the Pull Request or Push event is targeting.
+      - **Description**: This result identifies the target repository branch.
+
     - **git.url**: The Git URL from which the test pipeline is originating. This can be from a fork or the original repository.
       - **Description**: This result identifies the source repository URL, helping to trace back the origin of the code being tested. It is useful for verifying the source of the changes and ensuring they come from a trusted repository.
 


### PR DESCRIPTION
### Description

**tl;dr;** This PR introduces new Tekton Result field for `test-metadata` Task: `target-repo-branch`


Regarding branch names we have only `source-repo-branch` in test-metadata task.

That one is not sufficient if user would like to run integration tests on `push` events, because in that case the source branch annotation looks like this:
```
    pac.test.appstudio.openshift.io/source-branch: refs/heads/main
```
and it's complicated to use it in this format.

So for that case I thought it'd make sense to extract the value from the following annotation:
```
    pac.test.appstudio.openshift.io/branch: main
```
which points to:
* target branch name in case of `pull-request` event
* branch name in case of `push` event

### Verification
Tested with [my integration pipeline](https://github.com/psturc/nodejs-sl-test/blob/b3645c1993ef3d78d42520d94d30e93932fe0b95/integration-tests/pipelines/sealights-e2e.yaml#L19-L23) in PR and in push-event-triggered integration pipeline as well