### PR TITLE
feat(140): Add step action that help to upload ginkgo results to Sealights

### DIFF
--- a/stepactions/sealights/upload-ginkgo-results/0.1/README.md
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/README.md
@@ -1,0 +1,71 @@
+# Upload Ginkgo Results to Sealights
+
+This Tekton **StepAction** automates the process of uploading Ginkgo test results to Sealights. It handles the creation of a Sealights test session, processes a Ginkgo JSON report, uploads the test results, and cleans up resources by deleting the test session after the process is completed.
+
+## Parameters
+
+This StepAction supports the following parameters:
+
+| **Parameter Name**       | **Type**  | **Default Value**      | **Description**                                                                                         |
+|---------------------------|-----------|------------------------|---------------------------------------------------------------------------------------------------------|
+| `sealights-domain`        | `string`  | `redhat.sealights.co`  | The domain name of the Sealights server.                                                               |
+| `sealights-bsid`          | `string`  | `""`                   | The Sealights Build Session ID (BSID) associated with the build.                                       |
+| `test-stage`              | `string`  |                        | The name or identifier of the testing phase (e.g., `integration`, `e2e`). Used for categorizing results.|
+| `ginkgo-json-report-path` | `string`  |                        | The file path to the Ginkgo JSON report containing the test results.                                   |
+
+---
+
+## Environment Variables
+
+The following environment variables are used in this StepAction. These are automatically populated from the provided parameters:
+
+| **Environment Variable**      | **Populated From**       | **Description**                                                         |
+|-------------------------------|--------------------------|-------------------------------------------------------------------------|
+| `SEALIGHTS_DOMAIN`            | `sealights-domain`       | The domain name of the Sealights server.                               |
+| `SEALIGHTS_BSID`              | `sealights-bsid`         | The Sealights Build Session ID (BSID).                                 |
+| `GINKGO_JSON_REPORT_PATH`     | `ginkgo-json-report-path`| The file path to the Ginkgo JSON report.                               |
+| `TEST_STAGE`                  | `test-stage`             | The name or identifier of the testing phase.                           |
+| `SEALIGHTS_AGENT_TOKEN`       | From Kubernetes Secret   | The Sealights API token retrieved from the `sealights-credentials` secret. |
+
+---
+
+## Workflow
+
+1. **Create Test Session**: The StepAction starts by creating a new test session in Sealights.
+2. **Process Ginkgo JSON Report**: The Ginkgo test report is parsed, and test results are formatted into JSON.
+3. **Upload Test Results**: The processed test results are uploaded to the created Sealights test session.
+4. **Clean Up**: The test session is deleted.
+
+---
+
+## Example Usage
+
+Here’s an example Tekton YAML configuration using this StepAction:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upload-ginkgo-results-task
+spec:
+  steps:
+    # Previous steps goes here
+    - name: sealights-reporter
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
+      params:
+        - name: ginkgo-json-report-path
+          value: /workspace/artifact-dir/e2e-report.json
+        - name: test-stage
+          value: $(params.test-stage)
+        - name: sealights-bsid
+          value: $(params.sealights-bsid)
+```

--- a/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: upload-ginkgo-results
+spec:
+  description: |
+    "This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session,
+     processes the Ginkgo JSON report, sends the test results to Sealights, and then deletes the test session
+     to clean up resources."
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  params:
+    - name: sealights-domain
+      default: "redhat.sealights.co"
+      type: string
+      description: "The domain name of the Sealights server"
+    - name: sealights-bsid
+      type: string
+      description: "The Sealights Build Session ID (BSID) associated with a build."
+      default: ""
+    - name: test-stage
+      type: string
+      description: >-
+        "The name or identifier of the testing phase (e.g., "integration", "e2e") during which the results
+          are being captured. This helps distinguish the test results within Sealights for better reporting and traceability"
+    - name: ginkgo-json-report-path
+      type: string
+      description: "The file path to the Ginkgo JSON report that contains test results."
+  env:
+    - name: SEALIGHTS_DOMAIN
+      value: $(params.sealights-domain)
+    - name: SEALIGHTS_BSID
+      value: $(params.sealights-bsid)
+    - name: GINKGO_JSON_REPORT_PATH
+      value: $(params.ginkgo-json-report-path)
+    - name: TEST_STAGE
+      value: $(params.test-stage)
+    - name: SEALIGHTS_AGENT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: sealights-credentials
+          key: token
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+
+    echo "INFO: Creating Sealights test session..."
+    export TEST_SESSION_ID=$(curl -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
+      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"labId":"","testStage":"'${TEST_STAGE}'","bsid":"'${SEALIGHTS_BSID}'","sessionTimeout":10000}' | jq -r '.data.testSessionId')
+
+    if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
+      echo -e "[ERROR] Failed to retrieve test session ID"
+      exit 1
+    fi
+
+    echo -e "[INFO] Test session ID: $TEST_SESSION_ID"
+
+    process_test_report() {
+      jq -c '.[] | .SpecReports[]' "$GINKGO_JSON_REPORT_PATH" | while IFS= read -r line; do
+        name=$(echo "$line" | jq -r '.LeafNodeText')
+        start_raw=$(echo "$line" | jq -r '.StartTime')
+        end_raw=$(echo "$line" | jq -r '.EndTime')
+        status=$(echo "$line" | jq -r '.State')
+
+        start=$(date --date="$start_raw" +%s%3N)
+        end=$( [[ -z "$end_raw" || "$end_raw" == "0001-01-01T00:00:00Z" ]] && date +%s%3N || date --date="$end_raw" +%s%3N )
+
+        if [[ "$status" == "passed" || "$status" == "failed" ]]; then
+          echo "{\"name\": \"$name\", \"start\": $start, \"end\": $end, \"status\": \"$status\"}"
+        fi
+      done | jq -s '.'
+    }
+
+    echo -e "[INFO] Processing test report..."
+    PROCESSED_JSON=$(process_test_report)
+    echo -e "[INFO] Test report processed successfully"
+
+    echo "$PROCESSED_JSON" | jq .
+
+    echo -e "[INFO] Sending test results to Sealights..."
+    curl -s -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v2/test-sessions/$TEST_SESSION_ID" \
+      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$PROCESSED_JSON"
+
+    echo -e "[INFO] Deleting the test session..."
+    curl -s -X DELETE "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions/$TEST_SESSION_ID" \
+      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+      -H "Content-Type: application/json"
+
+    echo -e "[INFO] Test session deleted successfully"


### PR DESCRIPTION
This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session,  processes the Ginkgo JSON report, sends the test results to Sealights, and then deletes the test session to clean up resources.

Tested successfully in real app: https://github.com/konflux-ci/build-service/pull/393