### PR TITLE
feat(): Adapt get refs sealights task to build-definition tasks that were migrated

### DIFF
--- a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
+++ b/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
@@ -60,7 +60,7 @@ spec:
         SL_SOURCE_ARTIFACT="$(jq -r \
             '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
             select(.invocation.environment.labels."konflux-ci/sealights" == "true")
-            | .results[] | select(.name == "source-artifact") | .value' \
+            | .results[] | select(.name == "SOURCE_ARTIFACT") | .value' \
             cosign_metadata.json)"
 
         SL_CONTAINER_IMAGE="$(jq -r \


### PR DESCRIPTION
See pull request https://github.com/konflux-ci/build-definitions/pull/1868