### PR TITLE
feat(): Improve how we get the sealights images from a pristine image

### DIFF
--- a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
+++ b/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
@@ -63,11 +63,11 @@ spec:
             | .results[] | select(.name == "SOURCE_ARTIFACT") | .value' \
             cosign_metadata.json)"
 
-        SL_CONTAINER_IMAGE="$(jq -r \
-            --arg sl_source_artifact "$SL_SOURCE_ARTIFACT" \
-            '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
-            select(.invocation.parameters."SOURCE_ARTIFACT" == $sl_source_artifact)
-            | .results[] | select(.name == "IMAGE_REF") | .value' \
+        SL_CONTAINER_IMAGE="$(jq -r --arg sl_source_artifact "$SL_SOURCE_ARTIFACT" '
+            .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+            select(.invocation.parameters.SOURCE_ARTIFACT == $sl_source_artifact) |
+            select(.ref.params[].value == "buildah-oci-ta") | .results[] | select(.name == "IMAGE_REF") |
+            .value' \
             cosign_metadata.json)"
 
         SL_BUILD_NAME="$(jq -r \


### PR DESCRIPTION
Sometimes in TA we are getting the IMAGE_REF duplicated because is pushing the dockerfile as an artifact to quay. This pull request get the image digest and concat with IMAGE_URL which seems more accurate!

```json
    {
    "name": "CACHI2_ARTIFACT",
    "type": "string",
    "value": ""
    }
    {
    "name": "SOURCE_ARTIFACT",
    "type": "string",
    "value": "oci:quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service@sha256:1c566ecc87294c432f6de54e6f900d6bba1be3e5dc267ab373bf02ddb14e9677"
    }
    {
    "name": "IMAGE_DIGEST",
    "type": "string",
    "value": "sha256:d423b16d84360e2da3daa0cdbbb4d4c9d83a59900416e4f8dae407bea068726f"
    }
    {
    "name": "IMAGE_REF",
    "type": "string",
    "value": "quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service:on-pr-089213f1a212737f76ff4c7ea5e300d6f1db635f@sha256:d423b16d84360e2da3daa0cdbbb4d4c9d83a59900416e4f8dae407bea068726f"
    }
    {
    "name": "IMAGE_URL",
    "type": "string",
    "value": "quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service:on-pr-089213f1a212737f76ff4c7ea5e300d6f1db635f"
    }
    {
    "name": "SBOM_BLOB_URL",
    "type": "string",
    "value": "quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service@sha256:56e5eef55f94755bf801319bb1a0879b85345bae17223b1957fc0c566ce405d2"
    }
    {
    "name": "TEST_OUTPUT",
    "type": "string",
    "value": "{\"result\":\"FAILURE\",\"timestamp\":\"2025-01-31T13:04:52+00:00\",\"note\":\"For details, check Tekton task log.\",\"namespace\":\"default\",\"successes\":0,\"failures\":1,\"warnings\":0}\n"
    }
    {
    "name": "IMAGE_REF",
    "type": "string",
    "value": "quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service@sha256:2481c5199d9aea0b4e79f6f194f9b31814e3b76d27d4cee7551da4ad8b256b5a"
    }
```