### PR TITLE
fix: skip commenting for `Completed` pipeline run status

### DIFF
--- a/common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
@@ -139,7 +139,7 @@ spec:
         done
 
         # If the pipeline succeeded, do not post a new comment and exit
-        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" ]]; then
+        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" || "$PIPELINE_RUN_AGGREGATE_STATUS" == "Completed" ]]; then
             echo "[INFO]: Pipeline finished successfully. No new comment will be posted."
             exit 0
         fi


### PR DESCRIPTION
When using this task in the build-definitions CI, our CI pipeline run status is `Completed` sometimes based on the changes done in the PR, since some tasks are skipped, so it is pipeline run status is marked `Completed`. One such [example](https://github.com/konflux-ci/build-definitions/pull/1890#issuecomment-2630993291) . Changing the check in this task to skip commenting in the PR when the pipeline run status is `Completed` as well. 