### PR TITLE
feat(CVP-4397) Create a new step to verify the bundle is unreleased

### DIFF
--- a/stepactions/bundles/get-unreleased-bundle/0.1/README.MD
+++ b/stepactions/bundles/get-unreleased-bundle/0.1/README.MD
@@ -1,0 +1,56 @@
+# get-unreleased-bundle stepaction
+
+This StepAction retrieves the highest bundle version from a specified package, channel, and unreleased bundles list in the provided FBC fragment.
+If package name and/or channel name are not specified, the step will determine the default package and/or channel name.
+
+Default package name determination:
+* If there is only one 'olm.package', it's name is returned
+* If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user
+
+Default Channel Name Determination:
+* The default channel name corresponds to the 'defaultChannel' entry of the selected package
+
+The StepAction checks whether the highest bundle version is unreleased, specifically, not present in the Red Hat production Index Image (registry.redhat.io/redhat/redhat-operator-index).
+If the bundle is unreleased, the StepAction returns it.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|fbcFragment|A FBC fragment image.||true|
+|packageName|An OLM package name present in the fragment or leave it empty so the step will determine the default package name as described above.|""|false|
+|channelName|An OLM channel name or leave it empty so the step will determine the default channel name as described above.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|unreleasedBundle|The name of the bundle that is not in registry.redhat.io/redhat/redhat-operator-index.|
+
+## Example Usage
+
+Here’s an example Tekton YAML configuration using this StepAction:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-unreleased-bundle-task
+spec:
+  steps:
+    - name: get-unreleased-bundle
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
+      params:
+        - name: fbcFragment
+          value: $(params.fbcFragment)
+        - name: packageName
+          value: $(params.packageName)
+        - name: channelName
+          value: $(params.channelName)
+```

--- a/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
+++ b/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: get-unreleased-bundle
+spec:
+  description: >-
+    This StepAction retrieves the highest bundle version from a specified package, channel, and unreleased bundles list in the provided FBC fragment.
+    If package name and/or channel name are not specified, the step will determine the default package and/or channel name.
+    Default package name determination:
+      * If there is only one 'olm.package', it's name is returned
+      * If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user
+    Default Channel Name Determination:
+      * The default channel name corresponds to the 'defaultChannel' entry of the selected package
+    The StepAction checks whether the highest bundle version is unreleased, specifically, not present in the Red Hat production Index Image (registry.redhat.io/redhat/redhat-operator-index).
+    If the bundle is unreleased, the StepAction returns it.
+  image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+  params:
+    - name: fbcFragment
+      type: string
+      description: A FBC fragment image.
+    - name: packageName
+      type: string
+      description: Optional. An OLM package name present in the fragment or leave it empty so the step will determine the default package name as described above.
+      default: ""
+    - name: channelName
+      type: string
+      description: Optional. An OLM channel name or leave it empty so the step will determine the default channel name as described above.
+      default: ""
+  results:
+    - name: unreleasedBundle
+      description: The name of the bundle that is not in registry.redhat.io/redhat/redhat-operator-index.
+  env:
+    - name: FBC_FRAGMENT
+      value: $(params.fbcFragment)
+    - name: PACKAGE_NAME
+      value: $(params.packageName)
+    - name: CHANNEL_NAME
+      value: $(params.channelName)
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    . /utils.sh
+
+    if [ -z "$FBC_FRAGMENT" ]; then
+      echo "Error: FBC_FRAGMENT parameter is required." >&2
+      exit 1
+    fi
+
+    echo "Retrieving unreleased bundles..."
+    if ! unreleased_bundles=$(get_unreleased_bundles -i "$FBC_FRAGMENT"); then
+      echo "Could not get unreleased bundle images from the fragment. Make sure you have ImagePullCredentials for registry.redhat.io" >&2
+      exit 1
+    fi
+
+    if [ -z "${unreleased_bundles}" ]; then
+      echo "No unreleased bundles found. Exiting."
+      exit 0
+    fi
+    echo "Unreleased bundles found: $unreleased_bundles"
+
+    # Render the FBC fragment
+    if ! RENDER_OUT_FBC=$(render_opm -t "$FBC_FRAGMENT"); then
+      echo "Failed to render the FBC fragment" >&2
+      exit 1
+    fi
+
+    # Determine PACKAGE_NAME if not provided
+    if [ -z "$PACKAGE_NAME" ]; then
+      echo "Checking package association of unreleased bundles..."
+      package_image_map=$(group_bundle_images_by_package "$RENDER_OUT_FBC" "$unreleased_bundles")
+      echo "Package-image map: $package_image_map"
+      package_count=$(echo "$package_image_map" | jq 'keys | length')
+
+      if [[ "$package_count" -gt 1 ]]; then
+        echo "Error: Multiple packages detected. User must specify PACKAGE_NAME."
+        exit 1
+      fi
+
+      PACKAGE_NAME=$(echo "$package_image_map" | jq -r 'keys[0]')
+    fi
+    echo "Using package: $PACKAGE_NAME"
+
+    # Determine CHANNEL_NAME if not provided
+    if [ -z "$CHANNEL_NAME" ]; then
+      CHANNEL_NAME=$(get_channel_from_catalog "$RENDER_OUT_FBC" "$PACKAGE_NAME")
+      if [ -z "$CHANNEL_NAME" ]; then
+        echo "Failed to determine a default channel for package '$PACKAGE_NAME'" >&2
+        exit 1
+      fi
+    fi
+    echo "Using channel: $CHANNEL_NAME"
+
+    if ! highest_version_from_bundles_list=$(get_highest_version_from_bundles_list "$RENDER_OUT_FBC" "$PACKAGE_NAME" "$CHANNEL_NAME" "$unreleased_bundles"); then
+      echo "Failed to determine the highest bundle version" >&2
+      exit 1
+    fi
+    echo "Highest bundle: $highest_version_from_bundles_list"
+    echo "$highest_version_from_bundles_list" > $(step.results.unreleasedBundle.path)


### PR DESCRIPTION
This step retrieves the highest bundle version from a specified package and channel in a FBC fragment, then it verifies if this bundle is unreleased.
If the bundle is unreleased, the step returns it.

This step will be used by the "deploy-fbc" pipeline.