### PR TITLE
feat: renovate config for slnodejs and sl-python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["konflux/sealights-agents/nodejs/Dockerfile"],
+      "matchStrings": [
+        "RUN npm i -g slnodejs@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "slnodejs",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["konflux/sealights-agents/python/Dockerfile"],
+      "matchStrings": [
+        "RUN pip install sealights-python-agent==(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "sealights-python-agent",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "extends": [
+    "config:recommended"
+  ]
+}


### PR DESCRIPTION
I tested this config with renovate bot enabled in my fork of this repository:

* https://github.com/psturc/tekton-integration-catalog/pull/5
* https://github.com/psturc/tekton-integration-catalog/pull/6