### PR TITLE
feat(test-metadata): add support for downloading prefetch artifact

### DIFF
--- a/tasks/test-metadata/0.2/README.md
+++ b/tasks/test-metadata/0.2/README.md
@@ -10,6 +10,7 @@ The task accepts the following parameters:
 
 - **SNAPSHOT**: A JSON string representing the Snapshot under test. This JSON contains detailed information about the components and their sources.
 - **test-name**: A string representing the name of the test being executed.
+- **enable-prefetch**: Flag to indicate whether to retrieve the OCI artifact associated with the prefetching operation from the build phase. If set to true, the artifact's digest will be fetched.
 
 ### Example of SNAPSHOT
 
@@ -82,7 +83,8 @@ The task produces the following results:
 
   - **git.revision**: The Git branch from which the test pipeline is originating. This can be from a fork or the original repository.
     - **Description**: This result identifies the source repository branch, helping to trace back the origin of the code being tested. It is useful for verifying the source of the changes and ensuring they come from a trusted repository.
-
+- **prefetch-artifact**: The OCI artifact containing the prefetch dependencies generated during the build phase, if the 'enable-prefetch' parameter is enabled
+  
 ## Usage
 
 To effectively utilize the `test-metadata` task in a Tekton Pipeline, you can follow the example provided below. This example demonstrates how to define a Tekton pipeline that includes the `test-metadata` task, ensuring that all necessary parameters are specified correctly.

--- a/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/tasks/test-metadata/0.2/test-metadata.yaml
@@ -119,23 +119,13 @@ spec:
 
           cosign download attestation "$COMPONENT_CONTAINER_IMAGE" > cosign_metadata.json
 
-          OCI_STORAGE_LOCATION=$(jq -r '
-            .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
-            select(.name == "prefetch-dependencies") | .invocation.parameters.ociStorage' cosign_metadata.json)
+          CACHI2_SOURCE_ARTIFACT="$(jq -r \
+            '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+            select(.name == "prefetch-dependencies") | .results[] | select(.name == "CACHI2_ARTIFACT") | .value' \
+            cosign_metadata.json)"
+          
+          echo "[INFO] Cachi2 source artifact: $CACHI2_SOURCE_ARTIFACT"
 
-          echo "[INFO] OCI storage location: $OCI_STORAGE_LOCATION"
-
-          OCI_STORAGE_DIGEST=$(oras discover "$OCI_STORAGE_LOCATION" | grep -E 'sha256:[a-f0-9]{64}' | head -1)
-
-          echo "[INFO] OCI storage digest: $OCI_STORAGE_DIGEST"
-
-          CACHI2_ARTIFACT_DIGEST=$(oras manifest fetch "$OCI_STORAGE_DIGEST" | jq -r '
-            .layers[] | select(.annotations["org.opencontainers.image.title"] == "CACHI2_ARTIFACT") | .digest // empty')
-
-          OCI_REPOSITORY=$(echo "$OCI_STORAGE_DIGEST" | sed 's/@.*//')
-          FULL_OCI_ARTIFACT_PATH="$OCI_REPOSITORY@$CACHI2_ARTIFACT_DIGEST"
-          echo "[INFO] Full OCI Artifact Path: $FULL_OCI_ARTIFACT_PATH"
-
-          echo -n "oci:$FULL_OCI_ARTIFACT_PATH" > $(results.prefetch.path)
+          echo -n "$CACHI2_SOURCE_ARTIFACT" > $(results.prefetch-artifact.path)
           
         fi

--- a/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/tasks/test-metadata/0.2/test-metadata.yaml
@@ -12,12 +12,18 @@ spec:
   results:
     - name: job-spec
       description: The konflux ci job spec metadata generated.
+    - name: prefetch-artifact
+      description: The OCI artifact that contains the prefetch dependencies generated during the build phase.
   params:
     - name: SNAPSHOT
       description: The JSON string of the Snapshot under test.
     - name: test-name
       type: string
       description: The name of the test being executed.
+    - name: enable-prefetch
+      type: bool
+      description: Flag to indicate whether to retrieve the OCI artifact associated with the prefetching operation from the build phase. If set to true, the artifact's digest will be fetched.
+      default: false
   steps:
     - name: test-metadata
       image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
@@ -25,6 +31,8 @@ spec:
       env:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
+        - name: ENABLE_PREFETCH
+          value: $(params.enable-prefetch)
         - name: EVENT_TYPE
           valueFrom:
             fieldRef:
@@ -106,3 +114,28 @@ spec:
 
         # Write job-spec to result file
         echo -n "$JOB_SPEC" > $(results.job-spec.path)
+
+        if [ "$ENABLE_PREFETCH" == "true" ]; then
+
+          cosign download attestation "$COMPONENT_CONTAINER_IMAGE" > cosign_metadata.json
+
+          OCI_STORAGE_LOCATION=$(jq -r '
+            .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+            select(.name == "prefetch-dependencies") | .invocation.parameters.ociStorage' cosign_metadata.json)
+
+          echo "[INFO] OCI storage location: $OCI_STORAGE_LOCATION"
+
+          OCI_STORAGE_DIGEST=$(oras discover "$OCI_STORAGE_LOCATION" | grep -E 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "[INFO] OCI storage digest: $OCI_STORAGE_DIGEST"
+
+          CACHI2_ARTIFACT_DIGEST=$(oras manifest fetch "$OCI_STORAGE_DIGEST" | jq -r '
+            .layers[] | select(.annotations["org.opencontainers.image.title"] == "CACHI2_ARTIFACT") | .digest // empty')
+
+          OCI_REPOSITORY=$(echo "$OCI_STORAGE_DIGEST" | sed 's/@.*//')
+          FULL_OCI_ARTIFACT_PATH="$OCI_REPOSITORY@$CACHI2_ARTIFACT_DIGEST"
+          echo "[INFO] Full OCI Artifact Path: $FULL_OCI_ARTIFACT_PATH"
+
+          echo -n "oci:$FULL_OCI_ARTIFACT_PATH" > $(results.prefetch.path)
+          
+        fi


### PR DESCRIPTION
Added support to the `test-metadata` task to grab the OCI artifact that holds the prefetch dependencies from the build phase.

This allows integration tests to use prefetched dependencies while keeping the default behavior unchanged unless explicitly enabled.