### PR TITLE
fix(test-metadata): change boolean parameter to string in task

### DIFF
--- a/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/tasks/test-metadata/0.2/test-metadata.yaml
@@ -21,9 +21,9 @@ spec:
       type: string
       description: The name of the test being executed.
     - name: enable-prefetch
-      type: bool
-      description: Flag to indicate whether to retrieve the OCI artifact associated with the prefetching operation from the build phase. If set to true, the artifact's digest will be fetched.
-      default: false
+      type: string
+      description: Flag to indicate whether to retrieve the OCI artifact associated with the prefetching operation from the build phase. If set to "true", the artifact's digest will be fetched.
+      default: "false"
   steps:
     - name: test-metadata
       image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest


### PR DESCRIPTION
Tekton supports only strings, arrays, and objects for parameters; boolean values are not allowed. This commit updates the `enable-prefetch` parameter in the `test-metadata` task to use a string instead of a boolean.

Without this change, the task will fail in the webhook admission controller with the error:
`access denied the request: validation failed: invalid value: bool: spec.params.enable-prefetch.type`.