### PR TITLE
Fix jq error for push event type

### DIFF
--- a/common/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/common/tasks/test-metadata/0.2/test-metadata.yaml
@@ -79,7 +79,7 @@ spec:
             "konflux_component": "$KONFLUX_COMPONENT_NAME",
             "snapshot": $SNAPSHOT,
             "git": {
-                "pull_request_number": $PULL_REQUEST_NUMBER,
+                "pull_request_number": ${PULL_REQUEST_NUMBER:-0},
                 "pull_request_author": "$PR_AUTHOR",
                 "org": "$GIT_ORGANIZATION",
                 "repo": "$GIT_REPOSITORY",


### PR DESCRIPTION
For push event type the JOB_SPEC git [values](https://github.com/konflux-ci/tekton-integration-catalog/blob/main/common/tasks/test-metadata/0.2/test-metadata.yaml#L82) `"pull_request_number": ,` generated by test-metadata does not have even empty value, which leads jq command to error out with error:
```
GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
jq: parse error: Expected value before ',' at line 6, column 32
```

**JOB_SPEC:**

```json
{                                         
    "container_image": "quay.io/rhtap/rhtap-cli@sha256:f4f055b2a980445df8d1606ae777e543f2f7b65e973371d2f1823d4efcd6bf00",
    "konflux_component": "rhtap-cli",
    "snapshot": {"application":"rhtap-cli","components":[{"name":"rhtap-cli","containerImage":"quay.io/rhtap/rhtap-cli@sha256:f4f055b2a980445df8d1606ae777e543f2f7b65e973371d2f1823d4efcd6bf00","source":{"git":{"url":"https://github.com/redhat-appstudio/rhtap-cli","revision":"789c0c32e414c54439835fb56887ee9c2e4d36bf"}}}],"artifacts":{}},
    "git": {
        "pull_request_number": ,
        "pull_request_author": "null",
        "org": "redhat-appstudio",
        "repo": "rhtap-cli",
        "commit_sha": "789c0c32e414c54439835fb56887ee9c2e4d36bf",
        "event_type": "push",
        "source_repo_url": "https://github.com/redhat-appstudio/rhtap-cli",
        "source_repo_org": "redhat-appstudio",
        "source_repo_branch": "main",
        "target_repo_branch": "main",
        "url": "https://github.com/redhat-appstudio/rhtap-cli",
        "revision": "789c0c32e414c54439835fb56887ee9c2e4d36bf"
    }
}
```