### PR TITLE
feat(CVP-4398) Create a new step to pick cluster version

### DIFF
--- a/stepactions/bundles/pick-cluster-version/0.1/README.MD
+++ b/stepactions/bundles/pick-cluster-version/0.1/README.MD
@@ -1,0 +1,56 @@
+# pick-cluster-version stepaction
+
+This StepAction selects a cluster version for provisioning. It determines the target OCP version of an FBC fragment. 
+The version is returned if it is included in the list of supported Hypershift cluster versions.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|FBC_FRAGMENT|A FBC fragment image.||true|
+|CLUSTER_VERSIONS|List of supported minor versions from newest to oldest. E.g. ["4.15","4.14","4.13"]||true|
+
+## Results
+|name|description|
+|---|---|
+|ocpVersion|OCP version for cluster provisioning.|
+
+## Example Usage
+
+Here’s an example Tekton YAML configuration using this StepAction:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pick-cluster-version-task
+spec:
+  steps:
+    - name: get-supported-versions
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: $(params.eaasSpaceSecretRef)
+    - name: pick-cluster-version
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
+      params:
+        - name: fbcFragment
+          value: $(params.fbcFragment)
+        - name: clusterVersions
+          value: ["$(steps.get-supported-versions.results.versions[*])"]
+```

--- a/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
+++ b/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: pick-cluster-version
+spec:
+  description: >-
+    This StepAction selects a cluster version for provisioning. It determines the target OCP version of an FBC fragment.
+    The version is returned if it is included in the list of supported Hypershift cluster versions.
+  image: quay.io/redhat-appstudio/konflux-test:v1.4.18@sha256:78c76869d0b171e9bfa5e931e5e6ecbe92b32f61c6ec627c57cbb9d1aad75aab
+  params:
+    - name: fbcFragment
+      type: string
+      description: "An FBC fragment image."
+    - name: clusterVersions
+      type: array
+      description: "List of supported minor versions."
+  results:
+    - name: ocpVersion
+      description: "OCP version for cluster provisioning."
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    . /utils.sh
+
+    # Read parameters
+    FBC_FRAGMENT="$1"
+    shift
+    CLUSTER_VERSIONS=("$@")
+
+    # Validate inputs
+    if [ -z "$FBC_FRAGMENT" ]; then
+      echo "ERROR: fbcFragment parameter is required!" >&2
+      exit 1
+    fi
+
+    if [ ${#CLUSTER_VERSIONS[@]} -eq 0 ]; then
+      echo "ERROR: clusterVersions parameter is required and cannot be empty!" >&2
+      exit 1
+    fi
+    echo "Cluster versions: ${CLUSTER_VERSIONS[*]}"
+
+    if ! ocp_version=$(get_ocp_version_from_fbc_fragment "$FBC_FRAGMENT"); then
+      echo "ERROR: Failed to determine target OCP version from FBC fragment." >&2
+      exit 1
+    fi
+    echo "Target OCP version: $ocp_version"
+    
+    # Check if the OCP version exists in the cluster supported versions list
+    if printf "%s\n" "${CLUSTER_VERSIONS[@]}" | grep -Fxq "$ocp_version"; then
+      echo "$ocp_version" > "$(step.results.ocpVersion.path)"
+      echo "OCP version '$ocp_version' is in the cluster supported versions list."
+    else
+      echo "OCP version '$ocp_version' is NOT in the list of cluster supported versions: ${CLUSTER_VERSIONS[*]}" >&2
+      exit 1
+    fi
+  args:
+    - "$(params.fbcFragment)"
+    - "$(params.clusterVersions[*])"


### PR DESCRIPTION
This StepAction selects a cluster version for provisioning. It determines the target OCP version of an FBC fragment. 
The version is returned if it is included in the list of supported Hypershift cluster versions.
