### PR TITLE
feat: StepAction receive a new test session id and not create one directly

### DIFF
--- a/stepactions/sealights/create-test-session/0.1/README.md
+++ b/stepactions/sealights/create-test-session/0.1/README.md
@@ -1,0 +1,59 @@
+# Initialize Sealights Test Session
+
+Version: 0.1
+
+## Overview
+
+The `initialize-sealights-session` initializes a new Sealights test session by creating a session ID using the Sealights API and storing it for later use in the pipeline.
+
+## Features
+
+- Automatically generates a **Sealights Test Session ID**.
+- Stores the session ID as a result for use in later steps.
+- Retrieves the **Sealights Agent Token** securely from a Kubernetes secret.
+
+## Parameters
+
+| Parameter         | Type   | Description |
+|------------------|--------|-------------|
+| `sealights-bsid` | string | The **Build Session ID (BSID)** assigned to the current Sealights build. |
+| `test-stage`     | string | The stage of testing (e.g., `integration`, `e2e`). This helps categorize results in Sealights. |
+
+## Results
+
+| Result           | Description |
+|-----------------|-------------|
+| `test-session-id` | The generated **Sealights Test Session ID** that can be used in subsequent steps. |
+
+## Workflow
+
+1. **Check if Sealights is enabled**: The step runs only if `enable-sealights` is set to `"true"`.
+2. **Retrieve credentials**: The Sealights Agent Token is loaded from the `sealights-credentials` secret.
+3. **Create a test session**: A request is sent to the Sealights API to generate a test session ID.
+4. **Store the session ID**: The generated session ID is stored in the step results for future use.
+
+## Example Usage in a Tekton Pipeline
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: initialize-sealights-session-task
+spec:
+  steps:
+    - name: initialize-sealights-session
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/sealights/initialize-session/0.1/initialize-sealights-session.yaml
+      params:
+        - name: sealights-bsid
+          value: $(params.sealights-bsid)
+        - name: test-stage
+          value: $(params.test-stage)
+```

--- a/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
+++ b/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
@@ -1,62 +1,56 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
-  name: initialize-sealights-session
-  labels:
-    konflux-ci/sealights: "true"
-    app.kubernetes.io/version: "0.1"
-  annotations:
-    tekton.dev/pipelines.minVersion: 0.12.1
-    tekton.dev/tags: konflux
+  name: upload-ginkgo-results
 spec:
   description: |
-    This StepAction initializes a Sealights test session by creating a new session ID
-    using the Sealights API and storing it for later use.
+    "This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session
+     (if not provided), processes the Ginkgo JSON report, sends the test results to Sealights, and then deletes the test session."
+  image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
   params:
+    - name: sealights-domain
+      default: "redhat.sealights.co"
+      type: string
+      description: "The domain name of the Sealights server."
     - name: sealights-bsid
       type: string
-      description: "The Sealights Build Session ID (BSID) associated with the build."
+      description: "The Sealights Build Session ID (BSID) associated with a build."
+      default: ""
     - name: test-stage
       type: string
-      description: "The name or identifier of the testing phase (e.g., `integration`, `e2e`)."
-  results:
-    - name: test-session-id
-      description: "The Sealights test session ID generated in this step."
-  steps:
-    - name: initialize-sealights-session
-      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
-      env:
-        - name: SEALIGHTS_DOMAIN
-          value: "redhat.sealights.co"
-        - name: SEALIGHTS_BSID
-          value: $(params.sealights-bsid)
-        - name: TEST_STAGE
-          value: $(params.test-stage)
-        - name: SEALIGHTS_AGENT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: sealights-credentials
-              key: token
-      script: |
-        #!/bin/bash
-        set -euo pipefail
+      description: >-
+        "The name or identifier of the testing phase (e.g., "integration", "e2e") during which the results
+          are being captured. This helps distinguish the test results within Sealights for better reporting and traceability."
+  env:
+    - name: SEALIGHTS_DOMAIN
+      value: $(params.sealights-domain)
+    - name: SEALIGHTS_BSID
+      value: $(params.sealights-bsid)
+    - name: TEST_STAGE
+      value: $(params.test-stage)
+    - name: SEALIGHTS_AGENT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: sealights-credentials
+          key: token
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -z "$SEALIGHTS_BSID" ]]; then
+      echo "[ERROR] Sealights Build Session ID (BSID) is required."
+      exit 1
+    fi
 
-        if [[ -z "$SEALIGHTS_BSID" ]]; then
-          echo "[ERROR] Sealights Build Session ID (BSID) is required."
-          exit 1
-        fi
+    echo "[INFO] Creating Sealights test session..."
 
-        echo "[INFO] Creating Sealights test session..."
-        TEST_SESSION_ID=$(curl -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
-          -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d '{"labId":"","testStage":"'${TEST_STAGE}'","bsid":"'${SEALIGHTS_BSID}'","sessionTimeout":10000}' | jq -r '.data.testSessionId')
+    TEST_SESSION_ID=$(curl -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
+      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"labId":"","testStage":"'${TEST_STAGE}'","bsid":"'${SEALIGHTS_BSID}'","sessionTimeout":10000}' | jq -r '.data.testSessionId')
+    if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
+      echo "[ERROR] Failed to retrieve test session ID"
+      exit 1
+    fi
 
-        if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
-          echo "[ERROR] Failed to retrieve test session ID"
-          exit 1
-        fi
-
-        echo "[INFO] Test session ID: $TEST_SESSION_ID"
-
-        echo -n "$TEST_SESSION_ID" > $(step.results.test-session-id.path)
+    echo "[INFO] Test session ID: $TEST_SESSION_ID"
+    echo -n "$TEST_SESSION_ID" > $(step.results.test-session-id.path)

--- a/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
+++ b/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: initialize-sealights-session
+  labels:
+    konflux-ci/sealights: "true"
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+spec:
+  description: |
+    This StepAction initializes a Sealights test session by creating a new session ID
+    using the Sealights API and storing it for later use.
+  params:
+    - name: sealights-bsid
+      type: string
+      description: "The Sealights Build Session ID (BSID) associated with the build."
+    - name: test-stage
+      type: string
+      description: "The name or identifier of the testing phase (e.g., `integration`, `e2e`)."
+  results:
+    - name: test-session-id
+      description: "The Sealights test session ID generated in this step."
+  steps:
+    - name: initialize-sealights-session
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      env:
+        - name: SEALIGHTS_DOMAIN
+          value: "redhat.sealights.co"
+        - name: SEALIGHTS_BSID
+          value: $(params.sealights-bsid)
+        - name: TEST_STAGE
+          value: $(params.test-stage)
+        - name: SEALIGHTS_AGENT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sealights-credentials
+              key: token
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        if [[ -z "$SEALIGHTS_BSID" ]]; then
+          echo "[ERROR] Sealights Build Session ID (BSID) is required."
+          exit 1
+        fi
+
+        echo "[INFO] Creating Sealights test session..."
+        TEST_SESSION_ID=$(curl -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
+          -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d '{"labId":"","testStage":"'${TEST_STAGE}'","bsid":"'${SEALIGHTS_BSID}'","sessionTimeout":10000}' | jq -r '.data.testSessionId')
+
+        if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
+          echo "[ERROR] Failed to retrieve test session ID"
+          exit 1
+        fi
+
+        echo "[INFO] Test session ID: $TEST_SESSION_ID"
+
+        echo -n "$TEST_SESSION_ID" > $(step.results.test-session-id.path)

--- a/stepactions/sealights/upload-ginkgo-results/0.1/README.md
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/README.md
@@ -1,6 +1,8 @@
 # Upload Ginkgo Results to Sealights
 
-This Tekton **StepAction** automates the process of uploading Ginkgo test results to Sealights. It handles the creation of a Sealights test session, processes a Ginkgo JSON report, uploads the test results, and cleans up resources by deleting the test session after the process is completed.
+Version: 0.1
+
+This Tekton **StepAction** automates the process of uploading Ginkgo test results to Sealights. It handles the creation of a Sealights test session (if not already provided), processes a Ginkgo JSON report, uploads the test results, and ensures cleanup by always deleting the test session after the process is completed.
 
 ## Parameters
 
@@ -12,6 +14,7 @@ This StepAction supports the following parameters:
 | `sealights-bsid`          | `string`  | `""`                   | The Sealights Build Session ID (BSID) associated with the build.                                       |
 | `test-stage`              | `string`  |                        | The name or identifier of the testing phase (e.g., `integration`, `e2e`). Used for categorizing results.|
 | `ginkgo-json-report-path` | `string`  |                        | The file path to the Ginkgo JSON report containing the test results.                                   |
+| `test-session-id`         | `string`  | `""`                   | The ID of an existing test session. If provided, it will be used instead of creating a new one.       |
 
 ---
 
@@ -25,16 +28,17 @@ The following environment variables are used in this StepAction. These are autom
 | `SEALIGHTS_BSID`              | `sealights-bsid`         | The Sealights Build Session ID (BSID).                                 |
 | `GINKGO_JSON_REPORT_PATH`     | `ginkgo-json-report-path`| The file path to the Ginkgo JSON report.                               |
 | `TEST_STAGE`                  | `test-stage`             | The name or identifier of the testing phase.                           |
+| `TEST_SESSION_ID`             | `test-session-id`        | The ID of an existing test session (if provided).                      |
 | `SEALIGHTS_AGENT_TOKEN`       | From Kubernetes Secret   | The Sealights API token retrieved from the `sealights-credentials` secret. |
 
 ---
 
 ## Workflow
 
-1. **Create Test Session**: The StepAction starts by creating a new test session in Sealights.
+1. **Check for an Existing Test Session**: If `test-session-id` is provided, it is used directly. Otherwise, a new session is created.
 2. **Process Ginkgo JSON Report**: The Ginkgo test report is parsed, and test results are formatted into JSON.
-3. **Upload Test Results**: The processed test results are uploaded to the created Sealights test session.
-4. **Clean Up**: The test session is deleted.
+3. **Upload Test Results**: The processed test results are uploaded to the Sealights test session.
+4. **Ensure Cleanup**: A `trap` is used to always delete the test session, regardless of success or failure.
 
 ---
 
@@ -49,7 +53,7 @@ metadata:
   name: upload-ginkgo-results-task
 spec:
   steps:
-    # Previous steps goes here
+    # Previous steps go here
     - name: sealights-reporter
       onError: continue
       ref:
@@ -68,4 +72,6 @@ spec:
           value: $(params.test-stage)
         - name: sealights-bsid
           value: $(params.sealights-bsid)
+        - name: test-session-id
+          value: $(params.test-session-id)
 ```

--- a/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
@@ -4,15 +4,14 @@ metadata:
   name: upload-ginkgo-results
 spec:
   description: |
-    "This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session,
-     processes the Ginkgo JSON report, sends the test results to Sealights, and then deletes the test session
-     to clean up resources."
-  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+    "This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session
+     (if not provided), processes the Ginkgo JSON report, sends the test results to Sealights, and then deletes the test session."
+  image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
   params:
     - name: sealights-domain
       default: "redhat.sealights.co"
       type: string
-      description: "The domain name of the Sealights server"
+      description: "The domain name of the Sealights server."
     - name: sealights-bsid
       type: string
       description: "The Sealights Build Session ID (BSID) associated with a build."
@@ -21,15 +20,21 @@ spec:
       type: string
       description: >-
         "The name or identifier of the testing phase (e.g., "integration", "e2e") during which the results
-          are being captured. This helps distinguish the test results within Sealights for better reporting and traceability"
+          are being captured. This helps distinguish the test results within Sealights for better reporting and traceability."
     - name: ginkgo-json-report-path
       type: string
       description: "The file path to the Ginkgo JSON report that contains test results."
+    - name: test-session-id
+      type: string
+      description: "An ID of a test session that was already initialized previously for the Ginkgo tests."
+      default: ""
   env:
     - name: SEALIGHTS_DOMAIN
       value: $(params.sealights-domain)
     - name: SEALIGHTS_BSID
       value: $(params.sealights-bsid)
+    - name: TEST_SESSION_ID
+      value: $(params.test-session-id)
     - name: GINKGO_JSON_REPORT_PATH
       value: $(params.ginkgo-json-report-path)
     - name: TEST_STAGE
@@ -43,18 +48,32 @@ spec:
     #!/bin/bash
     set -euo pipefail
 
-    echo "INFO: Creating Sealights test session..."
-    export TEST_SESSION_ID=$(curl -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
-      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d '{"labId":"","testStage":"'${TEST_STAGE}'","bsid":"'${SEALIGHTS_BSID}'","sessionTimeout":10000}' | jq -r '.data.testSessionId')
+    cleanup() {
+      if [[ -n "$TEST_SESSION_ID" ]]; then
+        echo "[INFO] Deleting the test session..."
+        curl -s -X DELETE "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions/$TEST_SESSION_ID" \
+          -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+          -H "Content-Type: application/json"
+        echo "[INFO] Test session deleted successfully"
+      fi
+    }
 
-    if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
-      echo -e "[ERROR] Failed to retrieve test session ID"
-      exit 1
+    trap cleanup EXIT
+
+    if [[ -z "$TEST_SESSION_ID" ]]; then
+      echo "INFO: Creating Sealights test session..."
+      TEST_SESSION_ID=$(curl -s -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
+        -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"labId\":\"\",\"testStage\":\"$TEST_STAGE\",\"bsid\":\"$SEALIGHTS_BSID\",\"sessionTimeout\":10000}" | jq -r '.data.testSessionId')
+
+      if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
+        echo "[ERROR] Failed to retrieve test session ID"
+        exit 1
+      fi
     fi
 
-    echo -e "[INFO] Test session ID: $TEST_SESSION_ID"
+    echo "[INFO] Using test session ID: $TEST_SESSION_ID"
 
     process_test_report() {
       jq -c '.[] | .SpecReports[]' "$GINKGO_JSON_REPORT_PATH" | while IFS= read -r line; do
@@ -72,21 +91,14 @@ spec:
       done | jq -s '.'
     }
 
-    echo -e "[INFO] Processing test report..."
+    echo "[INFO] Processing test report..."
     PROCESSED_JSON=$(process_test_report)
-    echo -e "[INFO] Test report processed successfully"
+    echo "[INFO] Test report processed successfully"
 
     echo "$PROCESSED_JSON" | jq .
 
-    echo -e "[INFO] Sending test results to Sealights..."
+    echo "[INFO] Sending test results to Sealights..."
     curl -s -X POST "https://$SEALIGHTS_DOMAIN/sl-api/v2/test-sessions/$TEST_SESSION_ID" \
       -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
       -H "Content-Type: application/json" \
       -d "$PROCESSED_JSON"
-
-    echo -e "[INFO] Deleting the test session..."
-    curl -s -X DELETE "https://$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions/$TEST_SESSION_ID" \
-      -H "Authorization: Bearer $SEALIGHTS_AGENT_TOKEN" \
-      -H "Content-Type: application/json"
-
-    echo -e "[INFO] Test session deleted successfully"


### PR DESCRIPTION
There is a recommendation from Sealights to initialize the test session before we are executing the tests:

This Pull contain the following:
1. Dont create a session id if another one is comming in the params
2. Creates a trap to to delete always the session if already exists
3. Add a step action to initialize the test session separatelly