### PR TITLE
feat: add SL agent/cli versions to env vars

### DIFF
--- a/konflux/sealights-agents/go/Dockerfile
+++ b/konflux/sealights-agents/go/Dockerfile
@@ -2,10 +2,13 @@ FROM registry.redhat.io/ubi9/go-toolset:latest
 
 LABEL konflux.additional-tags="latest"
 
+ENV AGENT_VERSION=1.1.184
+ENV CLI_VERSION=1.0.46
+
 USER root
 
 # Installs Sealights Go agent and Sealights CLI
-RUN wget -qO- https://agents.sealights.co/slgoagent/v1.1.184/slgoagent-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
-RUN wget -qO- https://agents.sealights.co/slcli/v1.0.46/slcli-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
+RUN wget -qO- https://agents.sealights.co/slgoagent/v${AGENT_VERSION}/slgoagent-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
+RUN wget -qO- https://agents.sealights.co/slcli/v${CLI_VERSION}/slcli-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
 
 USER 1001

--- a/konflux/sealights-agents/nodejs/Dockerfile
+++ b/konflux/sealights-agents/nodejs/Dockerfile
@@ -2,5 +2,7 @@ FROM registry.redhat.io/ubi9/nodejs-22:latest
 
 LABEL konflux.additional-tags="latest"
 
+ENV AGENT_VERSION=6.1.1006
+
 # Installs Sealights Node.js agent
-RUN npm i -g slnodejs@6.1.1006
+RUN npm i -g slnodejs@${AGENT_VERSION}

--- a/konflux/sealights-agents/python/Dockerfile
+++ b/konflux/sealights-agents/python/Dockerfile
@@ -2,5 +2,7 @@ FROM registry.redhat.io/ubi9/python-311:latest
 
 LABEL konflux.additional-tags="latest"
 
+ENV AGENT_VERSION=2.2.5
+
 # Installs Sealights Python agent
-RUN pip install sealights-python-agent==2.2.5
+RUN pip install sealights-python-agent==${AGENT_VERSION}

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
       "customType": "regex",
       "fileMatch": ["konflux/sealights-agents/nodejs/Dockerfile"],
       "matchStrings": [
-        "RUN npm i -g slnodejs@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "ENV AGENT_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "npm",
       "depNameTemplate": "slnodejs",
@@ -15,7 +15,7 @@
       "customType": "regex",
       "fileMatch": ["konflux/sealights-agents/python/Dockerfile"],
       "matchStrings": [
-        "RUN pip install sealights-python-agent==(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "ENV AGENT_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "pypi",
       "depNameTemplate": "sealights-python-agent",


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-208

### Description
Adding a version of the agent/CLI to the Dockerfile's env var will make it easier to pass it to the Tekton Results (which will be done in a follow-up PR)

```
➜  tekton-integration-catalog git:(KFLUXDP-208) podman build -q --platform linux/arm64 -t test-nodejsagent . -f konflux/sealights-agents/nodejs/Dockerfile && \
podman run -it test-nodejsagent /bin/bash -c 'echo -e "\nAGENT VERSION: $AGENT_VERSION"'
107c17fa63aa35f7a0bb2340377d2f38572e1fed6fbd2e27e32e74c077002e85

AGENT VERSION: 6.1.1006
```