### PR TITLE
KFLUXDP-159: Add stepaction to gather cluster resources

### DIFF
--- a/stepactions/gather-cluster-resources/0.1/README.md
+++ b/stepactions/gather-cluster-resources/0.1/README.md
@@ -1,0 +1,17 @@
+# gather-cluster-resources stepaction
+
+This StepAction runs a script to gather konflux pipeline related artifacts and includes the possibility to run a
+second custom script to gather team related artifacts.
+We need to either pass the credentials to be mounted on the container with the path to the kubeconfig or
+pass directly the ocp login command.
+The gather-url should be passed as a list of urls ("<url_1>" "<url_2>")
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|credentials|A volume containing credentials to the remote cluster||false|
+|kubeconfig|Relative path to the kubeconfig in the mounted cluster credentials volume||false|
+|ocp-login-command|Command to log in to the OpenShift cluster||false|
+|gather-url|URL for the custom resource gathering script. Should be a list of strings||false|
+|artifact-dir|Relative path to where you want the artifacts to be stored||false|
+

--- a/stepactions/gather-cluster-resources/0.1/README.md
+++ b/stepactions/gather-cluster-resources/0.1/README.md
@@ -4,12 +4,15 @@ This StepAction runs a script to gather konflux pipeline related artifacts and i
 second custom script to gather team related artifacts.
 We need to either pass the credentials to be mounted on the container with the path to the kubeconfig or
 pass directly the ocp login command.
-The gather-url should be passed as a list of urls ("<url_1>" "<url_2>")
+If you choose to login via oc login command, please pass the credentials as a valid name of a valume that is of 
+emptyDir type.
+The gather-url should be passed as a list of urls ["<url_1>", "<url_2>"]. Don't pass this if you just want to 
+run the konflux related resources gathering job.
 
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|credentials|A volume containing credentials to the remote cluster||false|
+|credentials|A volume containing credentials to the remote cluster||true|
 |kubeconfig|Relative path to the kubeconfig in the mounted cluster credentials volume||false|
 |ocp-login-command|Command to log in to the OpenShift cluster||false|
 |gather-url|URL for the custom resource gathering script. Should be a list of strings||false|

--- a/stepactions/gather-cluster-resources/0.1/README.md
+++ b/stepactions/gather-cluster-resources/0.1/README.md
@@ -4,9 +4,9 @@ This StepAction runs a script to gather konflux pipeline related artifacts and i
 second custom script to gather team related artifacts.
 We need to either pass the credentials to be mounted on the container with the path to the kubeconfig or
 pass directly the ocp login command.
-If you choose to login via oc login command, please pass the credentials as a valid name of a valume that is of 
-emptyDir type.
-The gather-url should be passed as a list of urls ["<url_1>", "<url_2>"]. Don't pass this if you just want to 
+If you choose to login via oc login command, please pass the credentials as a valid name of a volume that is of 
+emptyDir type. In the example below, the empty-creds is a volume that would be valid for this case.
+The gather-urls should be passed as a list of urls ["<url_1>", "<url_2>"]. Don't pass this if you just want to 
 run the konflux related resources gathering job.
 
 ## Parameters
@@ -14,7 +14,47 @@ run the konflux related resources gathering job.
 |---|---|---|---|
 |credentials|A volume containing credentials to the remote cluster||true|
 |kubeconfig|Relative path to the kubeconfig in the mounted cluster credentials volume||false|
-|ocp-login-command|Command to log in to the OpenShift cluster||false|
-|gather-url|URL for the custom resource gathering script. Should be a list of strings||false|
+|oc-login-command|Command to log in to the OpenShift cluster||false|
+|gather-urls|A list of URLs for the custom resource gathering script||false|
 |artifact-dir|Relative path to where you want the artifacts to be stored||false|
 
+## Example Usage
+
+Below is an example of how to use this stepAction. 
+See this [example](https://github.com/konflux-ci/tekton-integration-catalog/blob/d533fcbaf34aca45eaf6176733af3b1446761fe9/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml#L47) on how you can share the working dir between steps
+Please note that there needs to either be a step populating the credentials volume with the kubeconfig or
+have the `oc login` command:
+```yaml
+- name: my-task-example
+      taskSpec:
+        volumes:
+          - name: empty-creds
+            emptyDir: {}
+          - name: creds-volume
+            secret: 
+              secretName: creds
+        steps:
+            - name: gather-resources
+              ref: 
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/tekton-integration-catalog
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+              params:
+                - name: credentials
+                  value: "creds-volume"
+                - name: kubeconfig
+                  value: "/path/to/kubeconfig" 
+                - name: artifact-dir
+                  value: /workspace/artifact-gathering
+            - name: list-artifacts
+              image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+              workingDir: "/workspace"
+              script: |
+                #!/bin/bash
+                ls -la /workspace/artifact-gathering
+```

--- a/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+++ b/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
@@ -21,14 +21,15 @@ spec:
       default: ""
     - name: gather-urls
       type: array
-      description: URL for the custom resource gathering script. Should be a list of strings
+      description: A list of URLs for the custom resource gathering script
       default: []
     - name: artifact-dir
       type: string
       description: Relative path to where you want the artifacts to be stored
-      default: "/artifacts"
+      default: "/workspace"
   args: 
     - $(params.gather-urls[*])
+  workingDir: $(params.artifact-dir)
   env:
     - name: KUBECONFIG
       value: "/credentials/$(params.kubeconfig)"
@@ -41,8 +42,16 @@ spec:
       mountPath: /credentials
   script: |
     #!/bin/bash
-    if [ -z "${KUBECONFIG}" ]; then 
-      echo "${OC_LOGIN_COMMAND}" | bash
+    set -x 
+    export AUX=${KUBECONFIG#*"/credentials/"}
+    if [ -z "${AUX}" ]; then 
+      unset KUBECONFIG
+      if [[ "${OC_LOGIN_COMMAND}" = *"oc login"* ]]; then
+        echo "${OC_LOGIN_COMMAND}" | bash
+      else
+        echo "Login error. Please provide a valid kubeconfig or a valid oc login command."
+        exit 1
+      fi
     fi
 
     curl -sSL https://raw.githubusercontent.com/konflux-ci/tekton-integration-catalog/main/scripts/gather-extra.sh | bash
@@ -52,4 +61,3 @@ spec:
         curl -sSL "${url}" | bash
       fi; 
     done
-    

--- a/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+++ b/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
@@ -14,36 +14,41 @@ spec:
     - name: kubeconfig
       type: string
       description: Relative path to the kubeconfig in the mounted cluster credentials volume
-    - name: ocp-login-command
+      default: ""
+    - name: oc-login-command
       type: string
       description: Command to log in to the OpenShift cluster
-    - name: gather-url
-      type: list
+      default: ""
+    - name: gather-urls
+      type: array
       description: URL for the custom resource gathering script. Should be a list of strings
-      default: ()
+      default: []
     - name: artifact-dir
       type: string
       description: Relative path to where you want the artifacts to be stored
       default: "/artifacts"
+  args: 
+    - $(params.gather-urls[*])
   env:
     - name: KUBECONFIG
       value: "/credentials/$(params.kubeconfig)"
-    - name: GATHER_URL
-      value: "$(params.gather-url)"
     - name: ARTIFACT_DIR
       value: "$(params.artifact-dir)"
+    - name: OC_LOGIN_COMMAND
+      value: "$(params.oc-login-command)"
   volumeMounts:
     - name: "$(params.credentials)"
       mountPath: /credentials
   script: |
-    #!/bin/sh
+    #!/bin/bash
     if [ -z "${KUBECONFIG}" ]; then 
-      $(params.oc-login-command)
+      echo "${OC_LOGIN_COMMAND}" | bash
     fi
 
-    curl -sSL https://raw.githubusercontent.com/konflux-ci/konflux-qe-definitions/main/scripts/gather-extra.sh | bash
-    for url in $GATHER_URL; 
-      do if ! [ -z "${url}" ]; then
+    curl -sSL https://raw.githubusercontent.com/konflux-ci/tekton-integration-catalog/main/scripts/gather-extra.sh | bash
+    for url in "$@"; do
+      if ! [ -z "${url}" ]; then
+        echo "curling ${url}"
         curl -sSL "${url}" | bash
       fi; 
     done

--- a/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+++ b/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: gather-cluster-resources
+spec:
+  description: >-
+    This StepAction executes the gather extra script that gathers konflux related resources from the cluster.
+    It also allows for a URL with another gather job to be passed to gather custom resources.
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  params:
+    - name: credentials
+      type: string
+      description: A volume containing credentials to the remote cluster
+    - name: kubeconfig
+      type: string
+      description: Relative path to the kubeconfig in the mounted cluster credentials volume
+    - name: ocp-login-command
+      type: string
+      description: Command to log in to the OpenShift cluster
+    - name: gather-url
+      type: list
+      description: URL for the custom resource gathering script. Should be a list of strings
+      default: ()
+    - name: artifact-dir
+      type: string
+      description: Relative path to where you want the artifacts to be stored
+      default: "/artifacts"
+  env:
+    - name: KUBECONFIG
+      value: "/credentials/$(params.kubeconfig)"
+    - name: GATHER_URL
+      value: "$(params.gather-url)"
+    - name: ARTIFACT_DIR
+      value: "$(params.artifact-dir)"
+  volumeMounts:
+    - name: "$(params.credentials)"
+      mountPath: /credentials
+  script: |
+    #!/bin/sh
+    if [ -z "${KUBECONFIG}" ]; then 
+      $(params.oc-login-command)
+    fi
+
+    curl -sSL https://raw.githubusercontent.com/konflux-ci/konflux-qe-definitions/main/scripts/gather-extra.sh | bash
+    for url in $GATHER_URL; 
+      do if ! [ -z "${url}" ]; then
+        curl -sSL "${url}" | bash
+      fi; 
+    done
+    


### PR DESCRIPTION
Add the stepaction to gather the cluster resources by running the gather-extra.sh script and give the user the possibility to run a script of their own that gathers resources that matter to their team.