### PR TITLE
feat(CVP-4402): Add deploy-operator pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ The **StepActions** directory houses modular building blocks that allow you to f
 - Reuse logic across multiple tasks.
 For further details on StepActions, refer to the [Tekton documentation](https://tekton.dev/docs/pipelines/stepactions/).
 
+### 🧩 Pipelines
+
+The **Pipelines** directory includes complete Tekton Pipelines composed of Tasks and StepActions. These Pipelines provide end-to-end examples of how to combine reusable components into robust CI/CD workflows. If you're looking to orchestrate multiple tasks into a cohesive flow, Pipelines are a great starting point.
+
+- **Adding a New Pipeline**:
+   To add a new pipeline, create a `.yaml` file inside the `pipelines/<your-pipeline-name>/0.1/` directory. Ensure it follows the Tekton [Pipeline specification](https://tekton.dev/docs/pipelines/pipelines/), is well-documented (add `README.md` file), and [well-versioned](#-versioning).
+
 ### 🧰 Konflux Integration Tools
 
 The **Konflux Integration Tools** provide utilities specifically designed to facilitate the development and management of Tekton tasks.

--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -1,0 +1,43 @@
+# "deploy-fbc-operator pipeline"
+The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift cluster and the deployment of an operator from a given FBC (File-Based Catalog) fragment. It automates the process of retrieving an unreleased bundle from the FBC, selecting an appropriate OpenShift version and architecture for cluster provisioning, installing the operator, and gathering cluster artifacts.
+
+## Pipeline Flow
+The pipeline consists of the following tasks:
+
+1. **Parse Metadata (`parse-metadata`)**  
+   Extracts metadata from the provided *snapshot*, including:
+     * FBC fragment container image
+     * Source Git URL
+     * Git revision
+
+2. **Provision EAAS Space (`provision-eaas-space`)**  
+   Allocates an **Ephemeral-as-a-Service (EaaS) space** for cluster provisioning.
+
+3. **Get Unreleased Bundle (`get-unreleased-bundle`)**
+   - Retrieves the **unreleased bundle** from the FBC fragment.
+   - Processes **.tekton/images-mirror-set.yaml** to resolve mirrored image references, if available.
+
+4. **Provision Cluster (`provision-cluster`)**  
+   - Fetches a list of supported **OpenShift versions** for Hypershift.
+   - Selects the **target OpenShift version** for deployment.
+   - Identifies the **supported cluster architecture** (`arm64`, `amd64`).
+   - Retrieves the latest OpenShift **version tag**.
+   - Provisions a **Hypershift AWS cluster** using the selected parameters.
+
+5. **Deploy Operator (`deploy-operator`)**  
+   - Retrieves **Kubeconfig credentials** for cluster access.
+   - Installs the **operator** on the newly provisioned cluster.
+   - Gathers **cluster artifacts** for analysis and validation.
+   - Verifies the cluster artifacts directory is downloaded.
+   - Pushes gathered artifacts to an **OCI artifact repository** (e.g. Quay).
+   - Fails the pipeline if operator installation fails.
+
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|snapshot| Snapshot of the application|| true|
+|package-name| An OLM package name present in the fragment or leave it empty so the step will determine the default package. If there is only one 'olm.package', it's name is returned. If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user| ""| false|
+|channel-name| An OLM channel name or leave it empty so the step will determine the default channel name. The default channel name corresponds to the 'defaultChannel' entry of the selected package| ""| false|
+|credentials-secret-name| Name of the secret containing the oci-storage-dockerconfigjson key with registry credentials in .dockerconfigjson format, used for pushing artifacts to an OCI registry|| true|
+|oci-ref| Full OCI artifact reference in a format "quay.io/org/repo:tag"|| true|

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -1,0 +1,620 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: deploy-fbc-operator
+spec:
+  description: |
+    The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift cluster and the deployment of an operator from a given FBC (File-Based Catalog) fragment.
+    It automates the process of retrieving an unreleased bundle from the FBC, selecting an appropriate OpenShift version and architecture for cluster provisioning,
+    installing the operator, and gathering cluster artifacts.
+  params:
+    - description: |
+        Spec section of an ApplicationSnapshot resource. Not all fields of the
+        resource are required. A minimal example:
+          {
+            "components": [
+              {
+                "containerImage": "quay.io/example/repo:latest",
+                "source": {
+                  "git": {
+                    "url": "https://github.com/org/repo",
+                    "revision": "6c1cbf4193930582d998770411f81d5c70aea29b"
+                  }
+                }
+              }
+            ]
+          }
+      name: snapshot
+      type: string
+    - description: |
+        An OLM package name present in the fragment or leave it empty so the step will determine the default package name. 
+        * If there is only one 'olm.package', it's name is returned.
+        * If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user.
+      name: package-name
+      default: ""
+      type: string
+    - description: |
+        An OLM channel name or leave it empty so the step will determine the default channel name. 
+        * The default channel name corresponds to the 'defaultChannel' entry of the selected package.
+      name: channel-name
+      default: ""
+      type: string
+    - description: |
+        Name of the secret containing the oci-storage-dockerconfigjson key with registry credentials in .dockerconfigjson format, used for pushing artifacts to an OCI registry.
+        Example:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: example
+            namespace: sample-tenant
+          type: Opaque
+          data:
+            oci-storage-dockerconfigjson: <BASE64_ENCODED_DOCKERCONFIGJSON>
+      name: credentials-secret-name
+      type: string
+    - description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
+      name: oci-ref
+      type: string
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.snapshot)
+    - name: provision-eaas-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push" ]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: get-unreleased-bundle
+      runAfter:
+        - provision-eaas-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push" ]
+      taskSpec:
+        results:
+          - name: unreleasedBundle
+            description: "Unreleased bundle image (may be mirrored)"
+          - name: packageName
+            value: "$(steps.get-unreleased-bundle.results.packageName)"
+          - name: channelName
+            value: "$(steps.get-unreleased-bundle.results.channelName)"
+        steps:
+          - name: get-unreleased-bundle
+            computeResources:
+              limits:
+                memory: 4Gi
+              requests:
+                memory: 4Gi
+                cpu: 500m
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
+            params:
+              - name: fbcFragment
+                value: "$(tasks.parse-metadata.results.component-container-image)"
+              - name: packageName
+                value: $(params.package-name)
+              - name: channelName
+                value: $(params.channel-name)
+          - name: process-image-mirror-set
+            image: quay.io/konflux-ci/konflux-test:v1.4.21@sha256:ddce6bc954694b55808507c1f92dfe9d094d52c636c8154c3fee441faff19f90
+            computeResources:
+              limits:
+                memory: 512Mi
+              requests:
+                memory: 512Mi
+                cpu: 100m
+            env:
+              - name: BUNDLE_IMAGE
+                value: "$(steps.get-unreleased-bundle.results.unreleasedBundle)"
+              - name: SOURCE_GIT_URL
+                value: "$(tasks.parse-metadata.results.source-git-url)"
+              - name: SOURCE_GIT_REVISION
+                value: "$(tasks.parse-metadata.results.source-git-revision)"
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              . /utils.sh
+
+              replaced_image=""
+
+              if [[ -z "${BUNDLE_IMAGE}" || "${BUNDLE_IMAGE}" == "null" ]]; then
+                echo "Unreleased bundle was not found. Cannot proceed with mirror substitution."
+                echo -n "$replaced_image" > "$(results.unreleasedBundle.path)"
+                exit 0
+              fi
+
+              mirror_set_url="${SOURCE_GIT_URL}/raw/${SOURCE_GIT_REVISION}/.tekton/images-mirror-set.yaml"
+              
+              if mirror_set_yaml=$(curl -sfL "${mirror_set_url}"); then
+                process_image_digest_mirror_set "${mirror_set_yaml}" > /tekton/home/mirror-map.txt
+              else
+                echo "Could not fetch image mirror set at ${mirror_set_url}. Unreleased bundles will fail opm render."
+                exit 1
+              fi
+
+              # Check and apply mirror mapping
+              if [ -s /tekton/home/mirror-map.txt ]; then
+                echo "Image Mirror Map found:"
+                cat /tekton/home/mirror-map.txt
+
+                reg_and_repo=$(echo "${BUNDLE_IMAGE}" | sed -E 's/^([^:@]+).*$/\1/')
+                first_mirror=$(jq -r --arg image "$reg_and_repo" '.[$image][0]' /tekton/home/mirror-map.txt)
+
+                if [ "$first_mirror" != "null" ]; then
+                  replaced_image=$(replace_image_pullspec "$BUNDLE_IMAGE" "$first_mirror")
+                  echo "Replacing $BUNDLE_IMAGE with $replaced_image"
+                fi
+              fi
+
+              echo -n "$replaced_image" > "$(results.unreleasedBundle.path)"
+    - name: provision-cluster
+      runAfter:
+        - get-unreleased-bundle
+      when:
+        - input: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+          operator: notin
+          values: [""]
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push" ]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: "$(tasks.provision-eaas-space.results.secretRef)"
+          - name: pick-cluster-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
+            params:
+              - name: fbcFragment
+                value: "$(tasks.parse-metadata.results.component-container-image)"
+              - name: clusterVersions
+                value: ["$(steps.get-supported-versions.results.versions[*])"]
+          - name: pick-cluster-arch
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/bundles/pick-cluster-arch/0.1/pick-cluster-arch.yaml
+            params:            
+              - name: bundleImage
+                value: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+          - name: get-latest-version-tag
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "$(steps.pick-cluster-version.results.ocpVersion)"
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: version
+                value: "$(steps.get-latest-version-tag.results.version)"
+    - name: deploy-operator
+      runAfter:
+        - provision-cluster
+      when:
+        - input: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+          operator: notin
+          values: [""]
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push" ]
+      params:
+        - name: eaasSpaceSecretRef
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: clusterName
+          value: "$(tasks.provision-cluster.results.clusterName)"
+        - name: fbcFragment
+          value: "$(tasks.parse-metadata.results.component-container-image)"
+        - name: bundleImage
+          value: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+        - name: packageName
+          value: "$(tasks.get-unreleased-bundle.results.packageName)"
+        - name: channelName
+          value: "$(tasks.get-unreleased-bundle.results.channelName)"
+      taskSpec:
+        params:
+          - name: eaasSpaceSecretRef
+            type: string
+          - name: clusterName
+            type: string
+          - name: fbcFragment
+            type: string
+          - name: bundleImage
+            type: string
+          - name: packageName
+            type: string
+          - name: channelName
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: oci-auth
+            secret:
+              secretName: $(params.credentials-secret-name)
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(params.eaasSpaceSecretRef)
+              - name: clusterName
+                value: $(params.clusterName)
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            # In case the test fails, we don't want to fail the TaskRun immediately,
+            # because we want to proceed with archiving the artifacts in a following step.
+            onError: continue
+            image: quay.io/konflux-ci/konflux-test:v1.4.21@sha256:ddce6bc954694b55808507c1f92dfe9d094d52c636c8154c3fee441faff19f90
+            computeResources:
+              limits:
+                memory: 4Gi
+              requests:
+                memory: 4Gi
+                cpu: 500m
+            env:
+              - name: FBC_FRAGMENT
+                value: "$(params.fbcFragment)"
+              - name: BUNDLE_IMAGE
+                value: "$(params.bundleImage)"
+              - name: PACKAGE_NAME
+                value: "$(params.packageName)"
+              - name: CHANNEL_NAME
+                value: "$(params.channelName)"
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              . /utils.sh
+
+              echo "[INFO] Using kubeconfig at $KUBECONFIG"
+              oc whoami || { echo "Failed to connect to cluster"; exit 1; }
+
+              for var in FBC_FRAGMENT BUNDLE_IMAGE PACKAGE_NAME CHANNEL_NAME; do
+                if [[ -z "${!var}" ]]; then
+                    echo "Error: $var parameter is required." >&2
+                    exit 1
+                fi
+              done
+
+              # Run opm render on a bundle image
+              if ! bundle_render_out=$(opm render "$BUNDLE_IMAGE"); then
+                echo "Failed to render the bundle image" >&2
+                exit 1
+              fi
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Retrieving 'operatorframework.io/suggested-namespace' metadata annotation if exists..."
+              INSTALL_NAMESPACE=$(get_bundle_suggested_namespace "$bundle_render_out")
+
+              if [[ -z "$INSTALL_NAMESPACE" ]]; then
+                echo "[$(date --utc +%FT%T.%3NZ)] No suggested namespace found, creating a new one"
+                NS_NAMESTANZA="generateName: oo-"
+              elif ! oc get namespace "$INSTALL_NAMESPACE"; then
+                echo "[$(date --utc +%FT%T.%3NZ)] Suggested namespace is '$INSTALL_NAMESPACE' which does not exist: creating"
+                NS_NAMESTANZA="name: $INSTALL_NAMESPACE"
+              else
+                echo "[$(date --utc +%FT%T.%3NZ)] INSTALL_NAMESPACE is '$INSTALL_NAMESPACE'"
+              fi
+
+              if [[ -n "${NS_NAMESTANZA:-}" ]]; then
+                INSTALL_NAMESPACE=$(
+                  oc create -f - -o jsonpath='{.metadata.name}' <<EOF
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                $NS_NAMESTANZA
+              EOF
+                )
+              fi
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Retrieving bundle install modes..."
+              if ! TARGET_NAMESPACES=$(get_bundle_install_modes "$bundle_render_out"); then
+                echo "Could not get target namespaces for the bundle" >&2
+                exit 1
+              fi
+
+              TARGET_NAMESPACES_FINAL=""
+
+              # Prioritize install modes in the correct order
+              if echo "$TARGET_NAMESPACES" | grep -q "AllNamespaces"; then
+                  echo "AllNamespaces is supported"
+                  TARGET_NAMESPACES_FINAL=""
+              elif echo "$TARGET_NAMESPACES" | grep -q "SingleNamespace"; then
+                  echo "SingleNamespace is supported"
+                  TARGET_NAMESPACES_FINAL="default"
+              elif echo "$TARGET_NAMESPACES" | grep -q "OwnNamespace"; then
+                  echo "OwnNamespace is supported"
+                  TARGET_NAMESPACES_FINAL="$INSTALL_NAMESPACE"
+              elif echo "$TARGET_NAMESPACES" | grep -q "MultiNamespace"; then
+                  echo "MultiNamespace is supported"
+                  TARGET_NAMESPACES_FINAL="openshift-marketplace,default"
+              else
+                  echo "Error: Unsupported TARGET_NAMESPACES value: $TARGET_NAMESPACES" >&2
+                  exit 1
+              fi
+
+              TARGET_NAMESPACES="$TARGET_NAMESPACES_FINAL"
+
+              OPERATORGROUP=$(oc -n "$INSTALL_NAMESPACE" get operatorgroup -o jsonpath="{.items[*].metadata.name}" || true)
+
+              if [[ $(echo "$OPERATORGROUP" | wc -w) -gt 1 ]]; then
+                  echo "[$(date --utc +%FT%T.%3NZ)] Error: multiple OperatorGroups in namespace \"$INSTALL_NAMESPACE\": $OPERATORGROUP" 1>&2
+                  echo "[$(date --utc +%FT%T.%3NZ)] Script Completed Execution With Failures!"
+                  exit 1
+              elif [[ -n "$OPERATORGROUP" ]]; then
+                  echo "[$(date --utc +%FT%T.%3NZ)] OperatorGroup \"$OPERATORGROUP\" exists: modifying it"
+                  OG_OPERATION=apply
+                  OG_NAMESTANZA="name: $OPERATORGROUP"
+              else
+                  echo "[$(date --utc +%FT%T.%3NZ)] OperatorGroup does not exist: creating it"
+                  OG_OPERATION=create
+                  OG_NAMESTANZA="generateName: oo-"
+              fi
+
+              OPERATORGROUP=$(
+                  oc $OG_OPERATION -f - -o jsonpath='{.metadata.name}' <<EOF
+              apiVersion: operators.coreos.com/v1
+              kind: OperatorGroup
+              metadata:
+                $OG_NAMESTANZA
+                namespace: $INSTALL_NAMESPACE
+              spec:
+                targetNamespaces: [$TARGET_NAMESPACES]
+              EOF
+              )
+
+              echo "[$(date --utc +%FT%T.%3NZ)] OperatorGroup name is \"$OPERATORGROUP\""
+
+              CS_NAMESTANZA="generateName: oo-"
+
+              CS_MANIFEST=$(cat <<EOF
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: CatalogSource
+              metadata:
+                $CS_NAMESTANZA
+                namespace: $INSTALL_NAMESPACE
+              spec:
+                sourceType: grpc
+                image: $FBC_FRAGMENT
+                grpcPodConfig:
+                  securityContextConfig: restricted
+                  extractContent:
+                    catalogDir: /configs
+                    cacheDir: /tmp/cache
+              EOF
+              )
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Creating CatalogSource:"
+              echo "$CS_MANIFEST"
+              CATSRC=$(oc create -f - -o jsonpath='{.metadata.name}' <<< "${CS_MANIFEST}" )
+              echo "[$(date --utc +%FT%T.%3NZ)] CatalogSource name is \"$CATSRC\""
+
+              # Waits up to 10 minutes until the Catalog source state is 'READY'
+              IS_CATSRC_CREATED=false
+              for i in $(seq 1 120); do
+                CATSRC_STATE=$(oc get catalogsources/"$CATSRC" -n "$INSTALL_NAMESPACE" -o jsonpath='{.status.connectionState.lastObservedState}')
+                echo $CATSRC_STATE
+                if [ "$CATSRC_STATE" = "READY" ]; then
+                  echo "[$(date --utc +%FT%T.%3NZ)] Catalogsource created successfully after waiting $((5*i)) seconds"
+                  echo "[$(date --utc +%FT%T.%3NZ)] Current state of catalogsource is \"$CATSRC_STATE\""
+                  IS_CATSRC_CREATED=true
+                  break
+                fi
+                sleep 5
+              done
+
+              if [ $IS_CATSRC_CREATED = false ]; then
+                echo "[$(date --utc +%FT%T.%3NZ)] Timed out waiting for the catalog source $CATSRC to become ready after 10 minutes."
+                echo "[$(date --utc +%FT%T.%3NZ)] Catalogsource state at timeout is \"$CATSRC_STATE\""
+                echo "[$(date --utc +%FT%T.%3NZ)] Script Completed Execution With Failures!"
+                exit 1
+              fi
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Set the deployment start time"
+
+              SUB_NAMESTANZA="generateName: oo-"
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Getting bundle name from image"
+              if ! bundleName=$(get_bundle_name "$bundle_render_out"); then
+                echo "Could not get a bundle name from a given image" >&2
+                exit 1
+              fi
+
+              SUB_MANIFEST=$(cat <<EOF
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: Subscription
+              metadata:
+                $SUB_NAMESTANZA
+                namespace: $INSTALL_NAMESPACE
+              spec:
+                name: $PACKAGE_NAME
+                channel: $CHANNEL_NAME
+                source: $CATSRC
+                sourceNamespace: $INSTALL_NAMESPACE
+                installPlanApproval: Manual
+                startingCSV: $bundleName
+              EOF
+              )
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Creating Subscription:"
+              echo "${SUB_MANIFEST}"
+
+              SUB=$(oc create -f - -o jsonpath='{.metadata.name}' <<< "${SUB_MANIFEST}" )
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Subscription name is \"$SUB\""
+
+              echo "[$(date --utc +%FT%T.%3NZ)] Waiting up to 5 minutes for installPlan to be created"
+              FOUND_INSTALLPLAN=false
+              for _ in $(seq 1 60); do
+                INSTALL_PLAN=$(oc -n "$INSTALL_NAMESPACE" get subscription "$SUB" -o jsonpath='{.status.installplan.name}' || true)
+
+                if [[ -n "$INSTALL_PLAN" ]]; then
+                  oc -n "$INSTALL_NAMESPACE" patch installPlan "${INSTALL_PLAN}" --type merge --patch '{"spec":{"approved":true}}'
+                  FOUND_INSTALLPLAN=true
+                  break
+                fi
+                sleep 5
+              done
+
+              if [ "$FOUND_INSTALLPLAN" = true ]; then
+                echo "[$(date --utc +%FT%T.%3NZ)] Install Plan approved"
+                echo "[$(date --utc +%FT%T.%3NZ)] Waiting up to 10 minutes for ClusterServiceVersion to become ready..."
+                
+                for _ in $(seq 1 60); do
+                  CSV=$(oc -n "$INSTALL_NAMESPACE" get subscription "$SUB" -o jsonpath="{.status.installedCSV}" || true)
+                  if [[ -n "$CSV" ]]; then
+                    if [[ "$(oc -n "$INSTALL_NAMESPACE" get csv "$CSV" -o jsonpath='{.status.phase}')" == "Succeeded" ]]; then
+                      echo "[$(date --utc +%FT%T.%3NZ)] ClusterServiceVersion \"$CSV\" ready"
+                      echo "[$(date --utc +%FT%T.%3NZ)] Script Completed Execution Successfully !"
+                      exit 0
+                    fi
+                  fi
+                  sleep 10
+                done
+
+                echo "[$(date --utc +%FT%T.%3NZ)] Timed out waiting for CSV to become ready"
+                exit 1
+              else
+                echo "[$(date --utc +%FT%T.%3NZ)] Failed to find installPlan for subscription"
+                exit 1
+              fi
+          - name: gather-cluster-resources
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+            params:
+              - name: credentials
+                value: "credentials"
+              - name: kubeconfig
+                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: artifact-dir
+                value: "/workspace/konflux-artifacts"
+          # validate that the cluster resources are available in another tekton step
+          - name: list-artifacts
+            image: quay.io/konflux-ci/konflux-test:v1.4.21@sha256:ddce6bc954694b55808507c1f92dfe9d094d52c636c8154c3fee441faff19f90
+            workingDir: "/workspace"
+            script: |
+              #!/bin/bash
+              ls -la /workspace
+          - name: push-artifacts
+            ref: 
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+            params:
+              - name: workdir-path
+                value: /workspace
+              - name: oci-ref
+                value: $(params.oci-ref):$(tasks.parse-metadata.results.source-git-revision)
+              - name: credentials-volume-name
+                value: oci-auth
+          - name: fail-if-any-step-failed
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
Note: the reason I'm using an inline script for the install-operator step is to workaround the issue of not being able to use workspaces in an integration pipeline: https://issues.redhat.com/browse/STONEINTG-1089

Slack thread: https://redhat-internal.slack.com/archives/C030SGP2VB9/p1743086568464209

Once STONEINTG-1089 is implemented I can modify an already existing install-operator step to use workspaces and reference it in the pipeline with `ref`: https://github.com/konflux-ci/tekton-integration-catalog/tree/main/stepactions/bundles/install-operator/0.1