### PR TITLE
fix: change pipeline params to upper case

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -36,8 +36,8 @@ The pipeline consists of the following tasks:
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|snapshot| Snapshot of the application|| true|
-|package-name| An OLM package name present in the fragment or leave it empty so the step will determine the default package. If there is only one 'olm.package', it's name is returned. If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user| ""| false|
-|channel-name| An OLM channel name or leave it empty so the step will determine the default channel name. The default channel name corresponds to the 'defaultChannel' entry of the selected package| ""| false|
-|credentials-secret-name| Name of the secret containing the oci-storage-dockerconfigjson key with registry credentials in .dockerconfigjson format, used for pushing artifacts to an OCI registry|| true|
-|oci-ref| Full OCI artifact reference in a format "quay.io/org/repo:tag"|| true|
+|SNAPSHOT| Snapshot of the application|| true|
+|PACKAGE_NAME| An OLM package name present in the fragment or leave it empty so the step will determine the default package. If there is only one 'olm.package', it's name is returned. If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user| ""| false|
+|CHANNEL_NAME| An OLM channel name or leave it empty so the step will determine the default channel name. The default channel name corresponds to the 'defaultChannel' entry of the selected package| ""| false|
+|CREDENTIALS_SECRET_NAME| Name of the secret containing the oci-storage-dockerconfigjson key with registry credentials in .dockerconfigjson format, used for pushing artifacts to an OCI registry|| true|
+|OCI_REF| Full OCI artifact reference in a format "quay.io/org/repo:tag"|| true|

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -24,19 +24,19 @@ spec:
               }
             ]
           }
-      name: snapshot
+      name: SNAPSHOT
       type: string
     - description: |
         An OLM package name present in the fragment or leave it empty so the step will determine the default package name. 
         * If there is only one 'olm.package', it's name is returned.
         * If multiple 'olm.package' entries contain unreleased bundles, user input is required; the PACKAGE_NAME parameter must be set by the user.
-      name: package-name
+      name: PACKAGE_NAME
       default: ""
       type: string
     - description: |
         An OLM channel name or leave it empty so the step will determine the default channel name. 
         * The default channel name corresponds to the 'defaultChannel' entry of the selected package.
-      name: channel-name
+      name: CHANNEL_NAME
       default: ""
       type: string
     - description: |
@@ -50,10 +50,10 @@ spec:
           type: Opaque
           data:
             oci-storage-dockerconfigjson: <BASE64_ENCODED_DOCKERCONFIGJSON>
-      name: credentials-secret-name
+      name: CREDENTIALS_SECRET_NAME
       type: string
     - description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
-      name: oci-ref
+      name: OCI_REF
       type: string
   tasks:
     - name: parse-metadata
@@ -68,7 +68,7 @@ spec:
             value: tasks/test_metadata.yaml
       params:
         - name: SNAPSHOT
-          value: $(params.snapshot)
+          value: $(params.SNAPSHOT)
     - name: provision-eaas-space
       runAfter:
         - parse-metadata
@@ -126,9 +126,9 @@ spec:
               - name: fbcFragment
                 value: "$(tasks.parse-metadata.results.component-container-image)"
               - name: packageName
-                value: $(params.package-name)
+                value: $(params.PACKAGE_NAME)
               - name: channelName
-                value: $(params.channel-name)
+                value: $(params.CHANNEL_NAME)
           - name: process-image-mirror-set
             image: quay.io/konflux-ci/konflux-test:v1.4.21@sha256:ddce6bc954694b55808507c1f92dfe9d094d52c636c8154c3fee441faff19f90
             computeResources:
@@ -309,7 +309,7 @@ spec:
             emptyDir: {}
           - name: oci-auth
             secret:
-              secretName: $(params.credentials-secret-name)
+              secretName: $(params.CREDENTIALS_SECRET_NAME)
         steps:
           - name: get-kubeconfig
             ref:
@@ -607,7 +607,7 @@ spec:
               - name: workdir-path
                 value: /workspace
               - name: oci-ref
-                value: $(params.oci-ref):$(tasks.parse-metadata.results.source-git-revision)
+                value: $(params.OCI_REF):$(tasks.parse-metadata.results.source-git-revision)
               - name: credentials-volume-name
                 value: oci-auth
           - name: fail-if-any-step-failed


### PR DESCRIPTION
The IntegrationTestScenario required to trigger the deploy-fbc-operator pipeline needs the SNAPSHOT parameter to be uppercase, so I updated the other parameters to use uppercase as well for consistency.
