### PR TITLE
fix: change return codes

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -181,7 +181,7 @@ spec:
               fi
 
               echo -n "$replaced_image" > "$(results.unreleasedBundle.path)"
-    - name: provision-cluster
+    - name: pick-cluster-params
       runAfter:
         - get-unreleased-bundle
       when:
@@ -193,8 +193,10 @@ spec:
           values: [ "push", "Push" ]
       taskSpec:
         results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
+          - name: ocpVersion
+            value: "$(steps.pick-cluster-version.results.ocpVersion)"
+          - name: bundleArch
+            value: "$(steps.pick-cluster-arch.results.bundleArch)"
         steps:
           - name: get-supported-versions
             ref:
@@ -237,6 +239,27 @@ spec:
             params:            
               - name: bundleImage
                 value: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+    - name: provision-cluster
+      runAfter:
+        - pick-cluster-params
+      when:
+        - input: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
+          operator: notin
+          values: [""]
+        - input: "$(tasks.pick-cluster-params.results.ocpVersion)"
+          operator: notin
+          values: [""]
+        - input: "$(tasks.pick-cluster-params.results.bundleArch)"
+          operator: notin
+          values: [""]
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push" ]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
           - name: get-latest-version-tag
             ref:
               resolver: git
@@ -249,7 +272,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "$(steps.pick-cluster-version.results.ocpVersion)"
+                value: "$(tasks.pick-cluster-params.results.ocpVersion)"
           - name: create-cluster
             ref:
               resolver: git
@@ -266,7 +289,7 @@ spec:
               - name: version
                 value: "$(steps.get-latest-version-tag.results.version)"
               - name: instanceType
-                value: "$(steps.pick-cluster-arch.results.bundleArch)"
+                value: "$(tasks.pick-cluster-params.results.bundleArch)"
     - name: deploy-operator
       runAfter:
         - provision-cluster

--- a/stepactions/bundles/install-operator/0.1/README.MD
+++ b/stepactions/bundles/install-operator/0.1/README.MD
@@ -22,10 +22,10 @@ This StepAction installs an operator from a provided FBC fragment.
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|FBC_FRAGMENT|A FBC fragment image.||true|
-|BUNDLE_IMAGE|Operator bundle to install on a cluster.||true|
-|PACKAGE_NAME|The name of the operator package to be installed.||true|
-|CHANNEL_NAME|The name of the operator channel to track.||true|
+|fbcFragment|A FBC fragment image.||true|
+|bundleImage|Operator bundle to install on a cluster.||true|
+|packageName|The name of the operator package to be installed.||true|
+|channelName|The name of the operator channel to track.||true|
 
 ## Example Usage
 

--- a/stepactions/bundles/pick-cluster-arch/0.1/pick-cluster-arch.yaml
+++ b/stepactions/bundles/pick-cluster-arch/0.1/pick-cluster-arch.yaml
@@ -48,6 +48,7 @@ spec:
       echo "amd64 architecture is supported"
       printf "m5.large" > $(step.results.bundleArch.path)
     else
-      echo "Neither arm64 nor amd64 is supported."
-      exit 1
+      echo "Neither arm64 nor amd64 is supported. Exiting as a no-op."
+      echo -n "" > "$(step.results.bundleArch.path)"
+      exit 0
     fi

--- a/stepactions/bundles/pick-cluster-version/0.1/README.MD
+++ b/stepactions/bundles/pick-cluster-version/0.1/README.MD
@@ -6,8 +6,8 @@ The version is returned if it is included in the list of supported Hypershift cl
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|FBC_FRAGMENT|A FBC fragment image.||true|
-|CLUSTER_VERSIONS|List of supported minor versions from newest to oldest. E.g. ["4.15","4.14","4.13"]||true|
+|fbcFragment|A FBC fragment image.||true|
+|clusterVersions|List of supported minor versions from newest to oldest. E.g. ["4.15","4.14","4.13"]||true|
 
 ## Results
 |name|description|

--- a/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
+++ b/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
@@ -53,8 +53,9 @@ spec:
       echo "$ocp_version" > "$(step.results.ocpVersion.path)"
       echo "OCP version '$ocp_version' is in the cluster supported versions list."
     else
-      echo "OCP version '$ocp_version' is NOT in the list of cluster supported versions: ${CLUSTER_VERSIONS[*]}" >&2
-      exit 1
+      echo "OCP version '$ocp_version' is NOT in the list of cluster supported versions: ${CLUSTER_VERSIONS[*]}. Exiting as a no-op."
+      echo -n "" > "$(step.results.ocpVersion.path)"
+      exit 0
     fi
   args:
     - "$(params.fbcFragment)"


### PR DESCRIPTION
Improving a few things in the `deploy-fbc-operator` pipeline.
-  If neither arm64 nor amd64 is supported, exit with code 0 as a no-op

- If a product team adds an ITS for a 4.18+ component,  exit with code 0 as a no-op (Hypershift currently supports 4.14–4.17.)