### PR TITLE
feat:(KONFLUX-6588): send data to quality dashboard even when fail and there is no junit

### DIFF
--- a/common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
+++ b/common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
@@ -51,10 +51,22 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['test.appstudio.openshift.io/scenario']
+        - name: IS_CANCELLED
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/cancelled']
         - name: E2E_REPORT_FILE
           value: $(params.e2e-report-file)
       script: |
         #!/bin/bash
+        set -e
+
+        # Exit early if the pipeline was cancelled
+        # TODO: In the future we can plan to monitor how many e2e tests got cancelled
+        if [ "$IS_CANCELLED" == "true" ]; then
+          echo "[INFO] Cancelled pipeline detected. No report will be sent to quality dashboard."
+          exit 0
+        fi
 
         # Set the event type to "pull_request" if it's not a push and has a PR number
         if [ "$EVENT_TYPE" != "push" ] && [ -n "$PULL_REQUEST_NUMBER" ]; then
@@ -90,7 +102,6 @@ spec:
         # Write the metadata JSON to a file
         echo "$METADATA_JSON" > metadata.json
 
-        # Debug output: display the content of metadata.json
         echo "[INFO] metadata.json content:"
         cat metadata.json
 
@@ -99,15 +110,16 @@ spec:
 
         QD_REPORT_FILENAME=$(find ./ -name "${E2E_REPORT_FILE}" | head -1)
 
-        if [ -z "$QD_REPORT_FILENAME" ]; then
-            echo "[INFO] No reports found with the specified name. Quality dashboard supports only to upload with reports"
-            exit 0
+        # Conditional upload: if the report is found, send it; else send only metadata
+        if [ -n "$QD_REPORT_FILENAME" ]; then
+          echo "[INFO] Report found: $QD_REPORT_FILENAME"
+          curl -F "metadata=@./metadata.json" \
+              -F "xunit=@$QD_REPORT_FILENAME" \
+              -X POST \
+              "$(params.quality-dashboard-api)/api/quality/konflux/metadata/post"
+        else
+          echo "[INFO] Report not found, sending only metadata."
+          curl -F "metadata=@./metadata.json" \
+              -X POST \
+              "$(params.quality-dashboard-api)/api/quality/konflux/metadata/post"
         fi
-
-        echo "[INFO] Report filename: $QD_REPORT_FILENAME"
-
-        # Upload the metadata and report to the quality dashboard
-        curl -F "metadata=@./metadata.json" \
-          -F "xunit=@$QD_REPORT_FILENAME" \
-          -X POST \
-          "$(params.quality-dashboard-api)/api/quality/konflux/metadata/post"


### PR DESCRIPTION
This Pull Request add the next logic:

* In case if the PipelineRun got cancelled by integration service then dont send any data to Quality Dashboard
* Send data to Quality Dashboard when Junit dont exist