### PR TITLE
feat(CLOUDDST-27042): Add support for private source code repos

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -11,7 +11,7 @@ The pipeline consists of the following tasks:
      * Git revision
 
 2. **Provision EAAS Space (`provision-eaas-space`)**  
-   Allocates an **Ephemeral-as-a-Service (EaaS) space** for cluster provisioning.
+   Allocates an **Environment-as-a-Service (EaaS) space** for cluster provisioning.
 
 3. **Get Unreleased Bundle (`get-unreleased-bundle`)**
    - Retrieves the **unreleased bundle** from the FBC fragment.
@@ -41,3 +41,5 @@ The pipeline consists of the following tasks:
 |CHANNEL_NAME| An OLM channel name or leave it empty so the step will determine the default channel name. The default channel name corresponds to the 'defaultChannel' entry of the selected package| ""| false|
 |CREDENTIALS_SECRET_NAME| Name of the secret containing the oci-storage-dockerconfigjson key with registry credentials in .dockerconfigjson format, used for pushing artifacts to an OCI registry|| true|
 |OCI_REF| Full OCI artifact reference in a format "quay.io/org/repo:tag"|| true|
+|REPO_TOKEN| Name of the Kubernetes Secret that contains the access token for a private GitHub or GitLab repository|| false|
+|REPO_KEY| Key within the Secret's "data" field that holds the GitHub/GitLab access token|| false|

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -55,6 +55,14 @@ spec:
     - description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
       name: OCI_REF
       type: string
+    - description: Name of the Kubernetes Secret that contains the access token for a private GitHub or GitLab repository
+      name: REPO_TOKEN
+      default: ""
+      type: string
+    - description: Key within the Secret's "data" field that holds the GitHub/GitLab access token
+      name: REPO_KEY
+      default: ""
+      type: string
   tasks:
     - name: parse-metadata
       taskRef:
@@ -144,6 +152,10 @@ spec:
                 value: "$(tasks.parse-metadata.results.source-git-url)"
               - name: SOURCE_GIT_REVISION
                 value: "$(tasks.parse-metadata.results.source-git-revision)"
+              - name: REPO_TOKEN
+                value: $(params.REPO_TOKEN)
+              - name: REPO_KEY
+                value: $(params.REPO_KEY)
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -168,9 +180,35 @@ spec:
               # Fetch and process mirror set
               mirror_set_url="${SOURCE_GIT_URL}/raw/${SOURCE_GIT_REVISION}/.tekton/images-mirror-set.yaml"
               
-              # Fetch mirror map from the URL
-              if mirror_set_yaml=$(curl -kfL "${mirror_set_url}"); then
-                process_image_digest_mirror_set "${mirror_set_yaml}" > /tekton/home/mirror-map.txt
+              # If REPO_TOKEN and REPO_KEY are defined, assume the source code repo is private and requires a token
+              if [[ -n "${REPO_TOKEN}" && -n "${REPO_KEY}" ]]; then
+                echo "Source code repository is private and requires a token to access it"
+
+                # Decode the token from the Kubernetes secret
+                TOKEN=$(kubectl get secret "$REPO_TOKEN" -o jsonpath="{.data.$REPO_KEY}" | base64 -d)
+                if [[ -z "$TOKEN" ]]; then
+                  echo "Failed to retrieve or decode token from secret '$REPO_TOKEN' key '$REPO_KEY'"
+                  exit 1
+                fi
+                
+                # Determine token header type
+                if [[ "$SOURCE_GIT_URL" == *"github.com"* ]]; then
+                  AUTH_HEADER="Authorization: token $TOKEN"
+                elif [[ "$SOURCE_GIT_URL" == *"gitlab."* ]]; then
+                  AUTH_HEADER="PRIVATE-TOKEN: $TOKEN"
+                else
+                  echo "Unknown Git provider. Cannot determine proper authorization header."
+                  exit 1
+                fi
+
+                # Fetch the file
+                mirror_set_yaml=$(curl -kfL -H "$AUTH_HEADER" "$mirror_set_url")
+              else
+                mirror_set_yaml=$(curl -kfL "$mirror_set_url")
+              fi
+
+              if [[ $? -eq 0 && -n "$mirror_set_yaml" ]]; then
+                process_image_digest_mirror_set "$mirror_set_yaml" > /tekton/home/mirror-map.txt
               else
                 echo "Could not fetch image mirror set at ${mirror_set_url}. Unreleased bundles will fail opm render."
                 exit 1
@@ -183,27 +221,39 @@ spec:
 
                 # Get registry and repo from BUNDLE_IMAGE
                 reg_and_repo=$(get_image_registry_and_repository "${BUNDLE_IMAGE}")
-                mapfile -t mirrors < <(jq -r --arg image "${reg_and_repo}" '.[$image][]' /tekton/home/mirror-map.txt)
-                echo "Mirrors for $reg_and_repo are:"
-                printf "%s\n" "${mirrors[@]}"
 
-                # Iterate over mirrors and try each one
-                for mirror in "${mirrors[@]}"; do
-                  echo "Attempting to use mirror ${mirror}"
-                  replaced_image=$(replace_image_pullspec "$BUNDLE_IMAGE" "$mirror")
+                # Check if there are any mirrors for the image
+                has_mirrors=$(jq -r --arg image "${reg_and_repo}" 'has($image)' /tekton/home/mirror-map.txt)
 
-                  # Check if the mirror is accessible
-                  if ! bundle_out=$(skopeo inspect --no-tags --config "docker://${replaced_image}"); then
-                    echo "Mirror $replaced_image is inaccessible."
-                    continue
+                if [[ "$has_mirrors" == "true" ]]; then
+                  mapfile -t mirrors < <(jq -r --arg image "${reg_and_repo}" '.[$image][]' /tekton/home/mirror-map.txt)
+                  
+                  echo "Mirrors for $reg_and_repo are:"
+                  printf "%s\n" "${mirrors[@]}"
+
+                  mirror_found=false
+                  # Iterate over mirrors and try each one
+                  for mirror in "${mirrors[@]}"; do
+                    echo "Attempting to use mirror ${mirror}"
+                    replaced_image=$(replace_image_pullspec "$BUNDLE_IMAGE" "$mirror")
+
+                    # Check if the mirror is accessible
+                    if ! bundle_out=$(skopeo inspect --no-tags --config "docker://${replaced_image}"); then
+                      echo "Mirror $replaced_image is inaccessible."
+                      continue
+                    fi
+
+                    echo "Replacing $BUNDLE_IMAGE with $replaced_image"
+                    mirror_found=true
+                    break
+                  done
+
+                  if [ "$mirror_found" = false ]; then
+                    echo "No valid mirrors found for $BUNDLE_IMAGE"
+                    exit 1
                   fi
-
-                  echo "Replacing $BUNDLE_IMAGE with $replaced_image"
-                  break
-                done
-
-                if [ -z "$replaced_image" ]; then
-                  echo "No valid mirrors found for $BUNDLE_IMAGE"
+                else
+                  echo "No mirrors found for $reg_and_repo in mirror map."
                   exit 1
                 fi
               else

--- a/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
+++ b/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
@@ -103,5 +103,5 @@ spec:
 
     echo "Highest bundle: $highest_version_from_bundles_list"
     echo -n -e "$highest_version_from_bundles_list" > "$(step.results.unreleasedBundle.path)"
-    echo "$PACKAGE_NAME" > "$(step.results.packageName.path)"
-    echo "$CHANNEL_NAME" > "$(step.results.channelName.path)"
+    echo -n "$PACKAGE_NAME" > "$(step.results.packageName.path)"
+    echo -n "$CHANNEL_NAME" > "$(step.results.channelName.path)"

--- a/stepactions/bundles/install-operator/0.1/install-operator.yaml
+++ b/stepactions/bundles/install-operator/0.1/install-operator.yaml
@@ -21,7 +21,7 @@ spec:
     5. Create the Subscription
     6. Approve the InstallPlan
     7. Wait for the ClusterServiceVersion to become Ready
-  image: quay.io/konflux-ci/konflux-test:v1.4.21@sha256:ddce6bc954694b55808507c1f92dfe9d094d52c636c8154c3fee441faff19f90
+  image: quay.io/konflux-ci/konflux-test:v1.4.24@sha256:47473fad67b5a5f4c3a701846ebcb0f732344b72aa12ad693d2313319b18930a
   params:
     - name: fbcFragment
       type: string
@@ -65,7 +65,7 @@ spec:
     echo "[$(date --utc +%FT%T.%3NZ)] Retrieving 'operatorframework.io/suggested-namespace' metadata annotation if exists..."
     INSTALL_NAMESPACE=$(get_bundle_suggested_namespace "$bundle_render_out")
 
-    if [[ -z "$INSTALL_NAMESPACE" ]]; then
+    if [[ -z "$INSTALL_NAMESPACE" || "$INSTALL_NAMESPACE" == null ]]; then
       echo "[$(date --utc +%FT%T.%3NZ)] No suggested namespace found, creating a new one"
       NS_NAMESTANZA="generateName: oo-"
     elif ! oc get namespace "$INSTALL_NAMESPACE"; then


### PR DESCRIPTION
1. Added support for accessing private GitHub and GitLab repositories.

General improvements:

- Added code to check if any mirrors exist for the image before iterating through them.

- Added the -n flag to the echo command when returning the package and channel name to remove the trailing newline.

- In the install-operator StepAction, incorporated changes that were previously introduced in the inline script within the pipeline to ensure consistency between both implementations.