### PR TITLE
Update Dockerfile to work with latest go version

### DIFF
--- a/konflux/sealights-agents/go/Dockerfile
+++ b/konflux/sealights-agents/go/Dockerfile
@@ -4,6 +4,7 @@ LABEL konflux.additional-tags="latest"
 
 ENV AGENT_VERSION=1.1.192
 ENV CLI_VERSION=1.0.46
+ENV GOTOOLCHAIN=auto
 
 USER root
 


### PR DESCRIPTION
```
error: error loading program packages: err: exit status 1: stderr: go: go.mod requires go >= 1.23.4 (running go 1.22.9; GOTOOLCHAIN=local)
```
This will fix an error during the scanning of Go projects with go version 1.23.X >.