### PR TITLE
Revert "feat: Auto destroy AWS stacks after 2h by default"

### DIFF
--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/Readme.md
@@ -48,7 +48,7 @@ This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outp
 | `version`                     | Kubernetes version                                                          | `v1.32`     | ❌       |
 | `tags`                        | AWS resource tags                                                           | `''`        | ❌       |
 | `debug`                       | Enable verbose output (prints credentials; use with caution)               | `false`     | ❌       |
-| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `2h`        | ❌       |
+| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `''`        | ❌       |
 
 ---
 

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
@@ -105,8 +105,8 @@ spec:
         Only use this for debugging in secure environments.
       default: 'false'
     - name: timeout
-      description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
-      default: "2h"
+      description: Auto-destroy timeout
+      default: "''"
 
   results:
     - name: cluster-access-secret


### PR DESCRIPTION
Reverts konflux-ci/tekton-integration-catalog#171