### PR TITLE
fix: link solve-pr-pairing script in v0.2

### DIFF
--- a/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
@@ -106,31 +106,23 @@ spec:
         - input: "$(params.component-name)"
           operator: notin
           values: [ "" ]
+      env:
+        - name: COMPONENT_NAME
+          value: "$(params.component-name)"
+        - name: PR_SOURCE_BRANCH
+          value: "$(params.component-pr-source-branch)"
+        - name: PR_AUTHOR
+          value: "$(params.component-pr-owner)"
+        - name: PR_SHA
+          value: "$(params.component-pr-sha)"
       script: |
         #!/bin/bash
         set -euo pipefail
 
         {
-          PR_SOURCE_BRANCH=$(params.component-pr-source-branch)
-          COMPONENT_NAME="$(params.component-name)"
-          PR_AUTHOR=$(params.component-pr-owner)
-
-          if [ $COMPONENT_NAME == "release-service-catalog" ]; then
-            PR_TO_PAIR=$(curl -s https://api.github.com/repos/konflux-ci/release-service/pulls\?per_page\=100 | jq -r ".[] | select(.user.login == \"$PR_AUTHOR\" and .head.ref == \"$PR_SOURCE_BRANCH\")")
-
-            if [ -n "$PR_TO_PAIR" ]; then
-              PAIRED_PR_SHA=$(jq -r '.head.sha' <<< $PR_TO_PAIR)
-
-              mkdir -p /var/workdir/
-              echo "COMPONENT_NAME=release-service" >> /var/workdir/.env
-              echo "IMAGE_REPO=quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service/release-service" >> /var/workdir/.env
-              echo "IMAGE_TAG=on-pr-$PAIRED_PR_SHA" >> /var/workdir/.env
-              echo "PR_OWNER=$PR_AUTHOR" >> /var/workdir/.env
-              echo "PR_SHA=$PAIRED_PR_SHA" >> /var/workdir/.env
-            fi
-          fi
+          echo "[INFO] Fetching and executing solve-pr-pairing.sh..."
+          curl -sSfL https://raw.githubusercontent.com/konflux-ci/tekton-integration-catalog/main/scripts/konflux-ci-deploy/solve-pr-pairing.sh | bash
         } 2>&1 | tee -a $LOG_FILENAME
-
     - name: update-kustomization
       image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
       onError: continue

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
@@ -140,7 +140,7 @@ spec:
           values: ["Succeeded"]
 
     - name: destroy
-      image: quay.io/redhat-developer/mapt:v0.9.1
+      image: quay.io/redhat-developer/mapt:v0.9.2
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
@@ -114,7 +114,7 @@ spec:
 
   steps:
     - name: provisioner
-      image: quay.io/redhat-developer/mapt:v0.9.1
+      image: quay.io/redhat-developer/mapt:v0.9.2
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -48,7 +48,7 @@ This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outp
 | `version`                     | Kubernetes version                                                          | `v1.32`     | ❌       |
 | `tags`                        | AWS resource tags                                                           | `''`        | ❌       |
 | `debug`                       | Enable verbose output (prints credentials; use with caution)               | `false`     | ❌       |
-| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `2h`        | ❌       |
+| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `''`        | ❌       |
 | `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
 | `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored.  | -    | ✅       |
 

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -110,8 +110,8 @@ spec:
         Only use this for debugging in secure environments.
       default: 'false'
     - name: timeout
-      description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
-      default: "2h"
+      description: Auto-destroy timeout
+      default: "''"
     - name: oci-ref
       type: string
       description: Full OCI artifact reference in a format "quay.io/org/repo:tag. It's used for storing logs from the Task's Steps

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -136,7 +136,7 @@ spec:
   steps:
     - name: provisioner
       onError: continue
-      image: quay.io/redhat-developer/mapt:v0.9.1
+      image: quay.io/redhat-developer/mapt:v0.9.2
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials


### PR DESCRIPTION
This PR fixes a couple of things:
* revert timeout value to empty string in kind-aws-provision Task
* bump version of mapt to v0.9.2 (fixes issue with logging kubeconfig to the output)