### PR TITLE
feat: decrease the default kind memory since we are overprovisioned

### DIFF
--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
@@ -75,11 +75,11 @@ spec:
     - name: cpus
       description: |
         The number of vCPUs to allocate to the virtual machine.
-      default: '16'
+      default: '8'
     - name: memory
       description: |
         The amount of memory (in GiB) to allocate to the virtual machine.
-      default: '64'
+      default: '32'
     - name: nested-virt
       description: |
         Enables nested virtualization if set to `true`. Useful for running Kind inside a VM.

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -11,7 +11,7 @@ metadata:
     tekton.dev/tags: infrastructure, aws, kind
     tekton.dev/displayName: "Kind Cloud Single Node - Create"
     tekton.dev/platforms: "linux/amd64, linux/arm64"
-    mapt/version: "v0.9.1"
+    mapt/version: "v0.9.2"
 spec:
   description: |
     Creates a single-node Kubernetes cluster using Kind on AWS, powered by the Mapt CLI.
@@ -80,11 +80,11 @@ spec:
     - name: cpus
       description: |
         The number of vCPUs to allocate to the virtual machine.
-      default: '16'
+      default: '8'
     - name: memory
       description: |
         The amount of memory (in GiB) to allocate to the virtual machine.
-      default: '64'
+      default: '32'
     - name: nested-virt
       description: |
         Enables nested virtualization if set to `true`. Useful for running Kind inside a VM.


### PR DESCRIPTION
From AWS graphics seems like we are overprovisioning kind clusters by default.

![Screenshot 2025-06-12 at 11 14 09](https://github.com/user-attachments/assets/8bbaec8d-e7ef-4e7a-80da-21c9a9ac3a7b)
