### PR TITLE
fix: create the kubeconfig secret at the begining of the provision task 

### DIFF
--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
@@ -91,7 +91,11 @@ spec:
       type: string
       description: |
         The registry secrets where artifacts will be stored.
-
+    - name: force-destroy
+      type: string
+      description: |
+        If force-destroy is set the command will destroy even if there is a lock when is still provisioning a stack.
+      default: "true"
   steps:
     - name: gather-cluster-resources
       onError: continue
@@ -157,6 +161,11 @@ spec:
         cmd="mapt aws kind destroy "
         cmd+="--project-name kind-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/kind/$(params.id) "
+
+        if [ "$(params.force-destroy)" = "true" ]; then
+          cmd+="--force-destroy "
+        fi
+
         eval "${cmd}"
       computeResources:
         requests:

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -135,7 +135,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "patch"]
 ```
 
 Bind this role to your pipeline's ServiceAccount with a `RoleBinding`:

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -11,7 +11,7 @@ metadata:
     tekton.dev/tags: infrastructure, aws, kind
     tekton.dev/displayName: "Kind Cloud Single Node - Create"
     tekton.dev/platforms: "linux/amd64, linux/arm64"
-    mapt/version: "v0.9.1"
+    mapt/version: "v0.9.2"
 spec:
   description: |
     Creates a single-node Kubernetes cluster using Kind on AWS, powered by the Mapt CLI.
@@ -55,7 +55,7 @@ spec:
       description: A unique identifier for this Kind environment
     - name: cluster-access-secret-name
       type: string
-      default: "''"
+      default: $(context.pipelineRun.name)
       description: |
         (Optional) The name to assign to the Kubernetes Secret that will store
         the kubeconfig for the created cluster. If not specified, a name will be auto-generated.
@@ -134,6 +134,46 @@ spec:
         mountPath: /var/log-dir
 
   steps:
+    - name: create-kubeconfig-secret
+      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      env:
+        - name: NAMESPACE
+          value: $(context.taskRun.namespace)
+        - name: OWNER_KIND
+          value: $(params.ownerKind)
+        - name: OWNER_NAME
+          value: $(params.ownerName)
+        - name: OWNER_UID
+          value: $(params.ownerUid)
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.cluster-access-secret-name)
+      script: |
+        #!/bin/bash
+        set -eo pipefail
+
+        echo "[INFO] Creating secret: $KUBECONFIG_SECRET_NAME"
+
+        cat <<EOF | oc create -f -
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${KUBECONFIG_SECRET_NAME}
+          namespace: ${NAMESPACE}
+          ownerReferences:
+          - apiVersion: tekton.dev/v1
+            kind: ${OWNER_KIND}
+            name: ${OWNER_NAME}
+            uid: ${OWNER_UID}
+        type: Opaque
+        data:
+          kubeconfig: ""
+        EOF
+
+        echo "[INFO] Successfully created secret: $KUBECONFIG_SECRET_NAME"
+
+        # Export secret name to result
+        echo -n "${KUBECONFIG_SECRET_NAME}" | tee $(results.cluster-access-secret.path)
+
     - name: provisioner
       onError: continue
       image: quay.io/redhat-developer/mapt:v0.9.2
@@ -177,50 +217,26 @@ spec:
           memory: "600Mi"
           cpu: "300m"
 
-    - name: host-info-secret
+    - name: update-kubeconfig-secret
       onError: continue
       image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)
-        - name: OWNER_KIND
-          value: $(params.ownerKind)
-        - name: OWNER_NAME
-          value: $(params.ownerName)
-        - name: OWNER_UID
-          value: $(params.ownerUid)
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.cluster-access-secret-name)
       volumeMounts:
         - name: cluster-info
           mountPath: /opt/cluster-info
       script: |
         #!/bin/bash
         set -eo pipefail
-        export SECRETNAME="generateName: mapt-aws-kind-"
-        if [[ $(params.cluster-access-secret-name) != "" ]]; then
-          export SECRETNAME="name: $(params.cluster-access-secret-name)"
-        fi
-        cat <<EOF > cluster-info.yaml
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          $SECRETNAME
-          namespace: $NAMESPACE
-          ownerReferences:
-          - apiVersion: tekton.dev/v1
-            kind: $OWNER_KIND
-            name: $OWNER_NAME
-            uid: $OWNER_UID
-        type: Opaque
-        data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
-        EOF
 
-        if [[ $(params.debug) == "true" ]]; then
-          cat /opt/cluster-info/*
-        fi
+        # Patch the existing secret to update the kubeconfig data
+        oc patch secret "${KUBECONFIG_SECRET_NAME}" -n "${NAMESPACE}" --type='merge' -p='{"data":{"kubeconfig":"'$(cat /opt/cluster-info/kubeconfig | base64 -w0)'"}}'
 
-        NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
-        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
+        echo "[INFO] Updated secret ${KUBECONFIG_SECRET_NAME} with kubeconfig."
+
     - name: secure-push-oci
       ref:
         resolver: git


### PR DESCRIPTION
This PR updates the kind-aws-provision task to always create the kubeconfig secret at the very beginning of the Task execution. Previously, the secret was only created if the cluster was successfully provisioned, which could cause issues during cleanup if provisioning cancelled/failed early.

