### PR TITLE
fix: sealights get ref: return only single match

### DIFF
--- a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
+++ b/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
@@ -83,9 +83,11 @@ spec:
             .payload
             | @base64d
             | fromjson
-            | .predicate.buildConfig.tasks[]
-            | select(.invocation.parameters.IMAGE? // "" | test("sealights"))
-            | .invocation.parameters.IMAGE
+            | first(
+              .predicate.buildConfig.tasks[]
+              | select(.invocation.parameters.IMAGE? // "" | test("sealights"))
+              | .invocation.parameters.IMAGE
+              )
           ' cosign_metadata.json)"
         fi
 


### PR DESCRIPTION
Fixes this issue when there's more than one task that matches the selector, which results multiple image refs printed out:

```
➜  /tmp jq -r '
            .payload
            | @base64d
            | fromjson
            | .predicate.buildConfig.tasks[]
            | select(.invocation.parameters.IMAGE? // "" | test("sealights"))
            | .invocation.parameters.IMAGE
          ' cosign_metadata.json
quay.io/rhdh/rhdh-hub-rhel9-sealights:1cd6092b9d79f36769cc8762b583cf6fea45d732
quay.io/rhdh/rhdh-hub-rhel9-sealights:1cd6092b9d79f36769cc8762b583cf6fea45d732
```