### PR TITLE
feat: prepare for build/integration e2e tests

### DIFF
--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -217,7 +217,9 @@ spec:
           kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/konflux-rbac/base/appstudio-pipelines-runner.yaml
 
           # Apply kyverno policy for reducing CPU/Memory requests for E2E PLR pods
-          kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/policies/development/taskruns-cluster-policy.yaml
+          curl -s https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/policies/development/taskruns-cluster-policy.yaml \
+            | yq 'del(.spec.rules[0].skipBackgroundRequests)' \
+            | kubectl apply -f -
 
           kubectl get po -A
         } 2>&1 | tee -a $LOG_FILENAME

--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -192,6 +192,17 @@ spec:
         set -euo pipefail
         
         {
+          server=$(grep server $KUBECONFIG | awk '{print $2}')
+          echo "[INFO] kubernetes cluster is hosted on: $server"
+
+          server_ip="${${server##*/}%:*}"
+
+          sed -i "s|localhost|${server_ip}|g" dependencies/dex/config.yaml
+          sed -i "s|localhost|${server_ip}|g" dependencies/pipelines-as-code/custom-console-patch.yaml
+          sed -i "s|localhost|${server_ip}|g" konflux-ci/ui/core/proxy/proxy.yaml
+
+          sed -i "s|http://pipelines-as-code-controller.*:|http://${server_ip}:|g" **/*.yaml
+
           kubectl cluster-info
 
           echo "[INFO] Installing Konflux CI dependencies"
@@ -200,6 +211,12 @@ spec:
 
           echo "[INFO] Installing Konflux CI..."
           ./deploy-konflux.sh
+
+          # Apply pipelines-runner cluster role
+          kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/konflux-rbac/base/appstudio-pipelines-runner.yaml
+
+          # Apply kyverno policy for reducing CPU/Memory requests for E2E PLR pods
+          kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/policies/development/taskruns-cluster-policy.yaml
 
           kubectl get po -A
         } 2>&1 | tee -a $LOG_FILENAME

--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -195,13 +195,14 @@ spec:
           server=$(grep server $KUBECONFIG | awk '{print $2}')
           echo "[INFO] kubernetes cluster is hosted on: $server"
 
-          server_ip="${${server##*/}%:*}"
+          server_ip=$(sed -e 's|.*/||' -e 's|:.*||' <<< $server)
 
           sed -i "s|localhost|${server_ip}|g" dependencies/dex/config.yaml
           sed -i "s|localhost|${server_ip}|g" dependencies/pipelines-as-code/custom-console-patch.yaml
           sed -i "s|localhost|${server_ip}|g" konflux-ci/ui/core/proxy/proxy.yaml
 
-          sed -i "s|http://pipelines-as-code-controller.*:|http://${server_ip}:|g" **/*.yaml
+          sed -i "s|http://pipelines-as-code-controller.*:|http://${server_ip}:|g" konflux-ci/build-service/core/build-service-env-patch.yaml
+          sed -i "s|http://pipelines-as-code-controller.*:|http://${server_ip}:|g" dependencies/smee/smee-client.yaml
 
           kubectl cluster-info
 

--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -216,11 +216,6 @@ spec:
           # Apply pipelines-runner cluster role
           kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/konflux-rbac/base/appstudio-pipelines-runner.yaml
 
-          # Apply kyverno policy for reducing CPU/Memory requests for E2E PLR pods
-          curl -s https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/policies/development/taskruns-cluster-policy.yaml \
-            | yq 'del(.spec.rules[0].skipBackgroundRequests)' \
-            | kubectl apply -f -
-
           kubectl get po -A
         } 2>&1 | tee -a $LOG_FILENAME
     - name: deploy-image-controller-and-smee
@@ -276,8 +271,11 @@ spec:
         set -euo pipefail
 
         {
-        echo "[INFO] Applying Kyverno to reduce resources for testing"
-        kubectl apply -f ./dependencies/kyverno/policy/e2e-reduce-resources.yaml
+        # Delete existing kyverno policies and apply a policy for reducing CPU/Memory requests for E2E PLR pods
+        kubectl delete clusterpolicy --all
+        curl -s https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/policies/development/taskruns-cluster-policy.yaml \
+          | yq 'del(.spec.rules[0].skipBackgroundRequests)' \
+          | kubectl apply -f -
 
         echo "[INFO] Creating Test Resources..."
         ./deploy-test-resources.sh

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -51,6 +51,7 @@ This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outp
 | `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `''`        | ❌       |
 | `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
 | `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored.  | -    | ✅       |
+| `extra-port-mappings`             | Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties. Example: '[{"containerPort": 30012, "hostPort": 8180, "protocol": "TCP"}, {"containerPort": 30013, "hostPort": 8280, "protocol": "TCP"}]'  | `''`    | ❌       |
 
 ---
 

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -51,7 +51,7 @@ This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outp
 | `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `''`        | ❌       |
 | `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
 | `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored.  | -    | ✅       |
-| `extra-port-mappings`             | Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties. Example: '[{"containerPort": 30012, "hostPort": 8180, "protocol": "TCP"}, {"containerPort": 30013, "hostPort": 8280, "protocol": "TCP"}]'  | `''`    | ❌       |
+| `extra-port-mappings`             | Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties. Example: '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}, {\"containerPort\":30013,\"hostPort\":8280,\"protocol\":\"TCP\"}]'  | `''`    | ❌       |
 
 ---
 

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -11,7 +11,7 @@ metadata:
     tekton.dev/tags: infrastructure, aws, kind
     tekton.dev/displayName: "Kind Cloud Single Node - Create"
     tekton.dev/platforms: "linux/amd64, linux/arm64"
-    mapt/version: "v0.9.2"
+    mapt/version: "v0.9.5"
 spec:
   description: |
     Creates a single-node Kubernetes cluster using Kind on AWS, powered by the Mapt CLI.
@@ -120,7 +120,12 @@ spec:
       description: |
         The secret name containing credentials for container registry where the artifacts will be stored.
       default: "konflux-test-infra"
-
+    - name: extra-port-mappings
+      type: string
+      description: |
+        Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties.
+        Example: '[{"containerPort": 30012, "hostPort": 8180, "protocol": "TCP"}, {"containerPort": 30013, "hostPort": 8280, "protocol": "TCP"}]'
+      default: ""
   results:
     - name: cluster-access-secret
       description: Secret with kubeconfig
@@ -176,7 +181,7 @@ spec:
 
     - name: provisioner
       onError: continue
-      image: quay.io/redhat-developer/mapt:v0.9.2
+      image: quay.io/redhat-developer/mapt:v0.9.5
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials
@@ -199,6 +204,7 @@ spec:
         cmd+="--arch $(params.arch) "
         cmd+="--cpus $(params.cpus) "
         cmd+="--memory $(params.memory) "
+        if [[ $(params.extra-port-mappings) != "" ]]; then cmd+="--extra-port-mappings $(params.extra-port-mappings) "; fi
         if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
         if [[ $(params.version) != "" ]]; then cmd+="--version $(params.version) "; fi
         if [[ $(params.spot) == "true" ]]; then

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -124,7 +124,7 @@ spec:
       type: string
       description: |
         Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties.
-        Example: '[{"containerPort": 30012, "hostPort": 8180, "protocol": "TCP"}, {"containerPort": 30013, "hostPort": 8280, "protocol": "TCP"}]'
+        Example: '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}, {\"containerPort\":30013,\"hostPort\":8280,\"protocol\":\"TCP\"}]'
       default: ""
   results:
     - name: cluster-access-secret


### PR DESCRIPTION
### List of changes
* update mapt version that supports exposing additional port (for PaC)
* update konflux-ci-deploy task to
  * update deployment of konflux-ci to replace localhost with mapt kind cluster's public IP so it's publicly accessible
  * add required pipelines-runner cluster role
  * add kyverno policy for reducing CPU/Memory requests for E2E PLR pods

### Testing
testing this change with https://github.com/konflux-ci/build-service/pull/448
