### PR TITLE
fix: extra-ports param empty value condition

### DIFF
--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -204,7 +204,7 @@ spec:
         cmd+="--arch $(params.arch) "
         cmd+="--cpus $(params.cpus) "
         cmd+="--memory $(params.memory) "
-        if [[ $(params.extra-port-mappings) != "" ]]; then cmd+="--extra-port-mappings $(params.extra-port-mappings) "; fi
+        if [[ "$(params.extra-port-mappings)" != "" ]]; then cmd+="--extra-port-mappings $(params.extra-port-mappings) "; fi
         if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
         if [[ $(params.version) != "" ]]; then cmd+="--version $(params.version) "; fi
         if [[ $(params.spot) == "true" ]]; then


### PR DESCRIPTION
Fixes this issue when `extra-port-mappings` param is not specified:

```
/tekton/scripts/script-1-72jvl: line 17: conditional binary operator expected
```