### PR TITLE
Add test-metadata v0.3 with enhanced functionality and container parsing

### DIFF
--- a/tasks/test-metadata/0.3/MIGRATION.md
+++ b/tasks/test-metadata/0.3/MIGRATION.md
@@ -1,0 +1,27 @@
+# Migration Guide: test-metadata 0.2 → 0.3
+
+## Key Changes
+
+### Enhanced Error Handling
+- **PR Author Retrieval**: Added `2>/dev/null || echo ""` to prevent silent failures
+- **SNAPSHOT Parsing**: All JQ commands now have error handling with fallback to empty string
+- **Validation**: Added required `KONFLUX_COMPONENT_NAME` validation
+
+### Prefetch Improvements
+- **Always Enabled**: Removed `enable-prefetch` parameter (now always on)
+- **Enhanced Support**: Added both CACHI2_ARTIFACT and SOURCE_ARTIFACT support
+- **Container Info**: Added container repository and tag extraction
+
+### New Results
+- `source-artifact`: Source artifact from prefetch operations
+- `container-repo`: Container repository extracted from image
+- `container-tag`: Container tag extracted from image
+
+## Breaking Changes
+- **Removed**: `enable-prefetch` parameter
+- **Removed**: `test-name` parameter
+
+## Migration
+1. Remove references to `enable-prefetch` and `test-name` parameters
+2. Prefetch is now automatic (no conditional handling needed)
+3. Task has better error handling - adjust pipeline error handling if needed 

--- a/tasks/test-metadata/0.3/README.md
+++ b/tasks/test-metadata/0.3/README.md
@@ -1,11 +1,5 @@
 # Test Metadata Version 0.3
 
-This version converges the functionality from both 0.1 and 0.2 versions, providing the best of both approaches:
-
-- **From 0.1**: Individual result outputs for easy access to specific metadata values
-- **From 0.2**: Consolidated job-spec approach with enhanced git information and prefetch functionality
-- **New in 0.3**: Combined approach with both individual results AND consolidated job-spec, plus prefetch capabilities
-
 The `test-metadata` task is designed to extract and log metadata from a JSON snapshot or PipelineRun object during a Tekton pipeline execution. This task helps in identifying and documenting critical information such as the event type (push or pull request), Git URL, Git revision, container image, GitHub organization, repository, pull request number, and pull request author.
 
 ## Parameters

--- a/tasks/test-metadata/0.3/README.md
+++ b/tasks/test-metadata/0.3/README.md
@@ -1,0 +1,204 @@
+# Test Metadata Version 0.3
+
+This version converges the functionality from both 0.1 and 0.2 versions, providing the best of both approaches:
+
+- **From 0.1**: Individual result outputs for easy access to specific metadata values
+- **From 0.2**: Consolidated job-spec approach with enhanced git information and prefetch functionality
+- **New in 0.3**: Combined approach with both individual results AND consolidated job-spec, plus prefetch capabilities
+
+The `test-metadata` task is designed to extract and log metadata from a JSON snapshot or PipelineRun object during a Tekton pipeline execution. This task helps in identifying and documenting critical information such as the event type (push or pull request), Git URL, Git revision, container image, GitHub organization, repository, pull request number, and pull request author.
+
+## Parameters
+
+The task accepts the following parameters:
+
+- **SNAPSHOT**: A JSON string representing the Snapshot under test. This JSON contains detailed information about the components and their sources.
+
+
+### Example of SNAPSHOT
+
+```json
+{
+  "components": [
+    {
+      "name": "component-1",
+      "source": {
+        "git": {
+          "url": "https://github.com/example/repo",
+          "revision": "commit-sha"
+        }
+      },
+      "containerImage": "quay.io/example/component-1:latest"
+    }
+  ]
+}
+```
+
+## Results
+
+The task produces the following results, combining both individual outputs (from 0.1) and consolidated approach (from 0.2):
+
+### Individual Results (0.1 approach)
+
+1. **test-event-type**: Indicates if the job is triggered by a Pull Request or a Push event.
+    - **Description**: This result helps to understand the context of the event that triggered the job. Knowing whether the job was triggered by a push (direct commit to the repository) or a pull request (a proposed change from a fork or a branch) can influence how the results are interpreted and acted upon.
+
+2. **pull-request-number**: The pull request number if the job is triggered by a pull request event.
+    - **Description**: This result provides the specific pull request number, which is crucial for tracking changes and associating test results with the correct pull request in a CI/CD system.
+
+3. **git-url**: The Git URL from which the test pipeline is originating. This can be from a fork or the original repository.
+    - **Description**: This result identifies the source repository URL, helping to trace back the origin of the code being tested. It is useful for verifying the source of the changes and ensuring they come from a trusted repository.
+
+4. **git-revision**: The Git revision (commit SHA) from which the test pipeline is originating.
+    - **Description**: This result specifies the exact commit SHA being tested, which is vital for reproducibility and debugging. It allows developers to know the precise state of the codebase at the time of testing.
+
+5. **container-image**: The container image built from the specified Git revision.
+    - **Description**: This result provides the reference to the container image that was built during the pipeline execution. It helps in verifying which image was produced from the specific code revision and is essential for deployment and further testing.
+
+6. **git-org**: The GitHub organization from which the test is originating.
+    - **Description**: This result indicates the organization or user namespace on GitHub where the repository resides. It helps in organizing and identifying the source of the code.
+
+7. **git-repo**: The repository from which the test is originating.
+    - **Description**: This result provides the name of the repository containing the code under test. It is useful for documentation, tracking, and context about the source of the changes.
+
+8. **pull-request-author**: The GitHub author of the pull request event.
+    - **Description**: This result identifies the author of the pull request, providing context about who made the changes.
+
+9. **source-repo-url**: Will show the source from where a Pull Request was opened. Can be from a fork or upstream.
+    - **Description**: This result identifies the source repository URL for pull requests, helping to trace back the origin of the changes.
+
+10. **source-repo-branch**: Get the branch from the fork or upstream repo where the pipeline is executed.
+    - **Description**: This result identifies the source repository branch for pull requests.
+
+11. **target-repo-branch**: The target branch value from the Pull Request or the current branch value in case of push event.
+    - **Description**: This result identifies the target repository branch.
+
+12. **component-name**: The name of the component that is being executed from Konflux.
+    - **Description**: This result provides the name of the Konflux component being tested.
+
+### Consolidated Results (0.2 approach)
+
+13. **job-spec**: The Konflux CI job spec metadata generated.
+    - **Description**: This result contains a JSON object with comprehensive details about the job specification, including container image, component name, git information, and event type. It encapsulates all the relevant metadata for the CI job in a structured format, aiding in documentation and analysis.
+
+    The job-spec contains the following structure:
+    ```json
+    {
+        "container_image": "quay.io/example/component:latest",
+        "konflux_component": "component-name",
+        "snapshot": { /* full snapshot JSON */ },
+        "git": {
+            "pull_request_number": "123",
+            "pull_request_author": "username",
+            "org": "organization",
+            "repo": "repository",
+            "commit_sha": "abc123",
+            "event_type": "pull_request",
+            "source_repo_url": "https://github.com/fork/repo",
+            "source_repo_org": "fork",
+            "source_repo_branch": "feature-branch",
+            "target_repo_branch": "main",
+            "url": "https://github.com/org/repo",
+            "revision": "abc123"
+        }
+    }
+    ```
+
+### Prefetch Results (0.2 approach)
+
+14. **prefetch-artifact**: The OCI artifact that contains the prefetch dependencies generated during the build phase.
+    - **Description**: This result contains the digest of the OCI artifact that was generated during the build phase's prefetch-dependencies task. The prefetch functionality is always enabled in this version. If no artifact is found, this will be an empty string.
+
+15. **source-artifact**: The source artifact extracted from the container image attestation.
+    - **Description**: This result contains the source artifact digest extracted from the container image attestation during the prefetch-dependencies task. If no artifact is found, this will be an empty string.
+
+16. **container-repo**: The container repository extracted from the container image.
+    - **Description**: This result contains the repository part of the container image (e.g., quay.io/org/repo). It is extracted by parsing the container image URL and removing the tag and SHA256 digest.
+
+17. **container-tag**: The container tag extracted from the container image.
+    - **Description**: This result contains the tag part of the container image. If no tag is present in the original image, it defaults based on the event type: "on-pr-{revision}" for pull requests or "{revision}" for push events.
+
+## Key Features
+
+### Combined Approach
+- **Individual Results**: Easy access to specific metadata values without parsing JSON
+- **Consolidated Job-Spec**: Complete metadata in a structured JSON format
+- **Backward Compatibility**: Supports both 0.1 and 0.2 usage patterns
+- **Enhanced Artifacts**: Both prefetch and source artifacts available
+
+### Enhanced Git Information
+- **Source Repository Details**: Full information about source repositories for pull requests
+- **Organization Extraction**: Automatic extraction of source repository organization
+- **Complete Git Context**: All git-related information in both individual and consolidated formats
+
+### Prefetch Functionality
+- **Always Enabled**: Prefetch functionality is always active
+- **OCI Artifact Integration**: Downloads and processes cosign attestations
+- **Cachi2 Integration**: Extracts Cachi2 artifacts from build phase
+- **Dual Artifacts**: Both CACHI2_ARTIFACT and SOURCE_ARTIFACT are extracted
+- **Graceful Handling**: Empty artifacts return empty strings with appropriate warnings
+- **Status Logging**: Provides concise status output showing artifact availability and values
+
+### Container Image Parsing
+- **Repository Extraction**: Automatically extracts repository from container image URL
+- **Tag Extraction**: Extracts tag from container image with smart defaults
+- **Event-Based Defaults**: Uses git revision for missing tags with event-specific formatting
+
+Example output:
+```
+[INFO] Cachi2 artifact: found (sha256:abc123...), Source artifact: not found
+[INFO] No tag found, defaulting to: on-pr-abc123def
+```
+
+## Usage
+
+To effectively utilize the `test-metadata` task in a Tekton Pipeline, you can follow the example provided below. This example demonstrates how to define a Tekton pipeline that includes the `test-metadata` task, ensuring that all necessary parameters are specified correctly.
+
+### Basic Usage (0.1 style)
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-metadata-pipeline
+spec:
+  tasks:
+    - name: extract-build-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test-metadata/0.3/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: "<your-snapshot-json>"
+```
+
+
+
+## Migration from Previous Versions
+
+### From 0.1 to 0.3
+- All individual results are preserved
+- Additional `job-spec` result provides consolidated access
+- New `prefetch-artifact` result always available
+- Enhanced git information with `source_repo_org`
+- New container parsing results (`container-repo`, `container-tag`)
+- Simplified parameters (only SNAPSHOT required)
+
+### From 0.2 to 0.3
+- All consolidated functionality preserved
+- Individual results now available for easier access
+- New container parsing results (`container-repo`, `container-tag`)
+- Enhanced logging and debugging information
+- Simplified parameters (only SNAPSHOT required)
+
+## Version History
+
+- **0.1**: Individual result outputs for specific metadata values
+- **0.2**: Consolidated job-spec approach with prefetch functionality
+- **0.3**: Combined approach with both individual and consolidated results, plus enhanced git information 

--- a/tasks/test-metadata/0.3/test-metadata.yaml
+++ b/tasks/test-metadata/0.3/test-metadata.yaml
@@ -1,0 +1,228 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-metadata
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+spec:
+  description: |
+    The `test-metadata` Task is responsible for gathering and processing metadata during the execution of a pipeline test.
+    It collects various Git and repository details, such as the type of event that triggered the pipeline (Push or Pull Request),
+    the Git URL and revision, and details about the container image built during the test.
+    The task processes metadata labels and annotations, constructs a job specification for the Konflux CI system,
+    and writes this information to specified results. This version combines the individual result approach from 0.1
+    with the consolidated job-spec approach from 0.2, plus prefetch functionality.
+  results:
+    - name: test-event-type
+      description: Indicates if the job is triggered by a Pull Request or a Push event.
+    - name: pull-request-number
+      description: The pull request number if the job is triggered by a pull request event.
+    - name: git-url
+      description: The Git URL from which the test pipeline is originating. This can be from a fork or the original repository.
+    - name: git-revision
+      description: The Git revision (commit SHA) from which the test pipeline is originating.
+    - name: container-image
+      description: The container image built from the specified Git revision.
+    - name: git-org
+      description: The GitHub organization from which the test is originating.
+    - name: git-repo
+      description: The repository from which the test is originating.
+    - name: pull-request-author
+      description: The GitHub author of the pull request event.
+    - name: job-spec
+      description: The Konflux CI job spec metadata generated.
+    - name: source-repo-url
+      description: Will show the source from where a Pull Request was opened. Can be from a fork or upstream.
+    - name: source-repo-branch
+      description: Get the branch from the fork or upstream repo where the pipeline is executed.
+    - name: target-repo-branch
+      description: The target branch value from the Pull Request or the current branch value in case of push event. 
+    - name: component-name
+      description: The name of the component that is being executed from Konflux.
+    - name: prefetch-artifact
+      description: The OCI artifact that contains the prefetch dependencies generated during the build phase.
+    - name: container-repo
+      description: The container repository extracted from the container image.
+    - name: container-tag
+      description: The container tag extracted from the container image.
+  params:
+    - name: SNAPSHOT
+      description: The JSON string of the Snapshot under test.
+
+  steps:
+    - name: test-metadata
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      workingDir: /workspace
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+
+        - name: EVENT_TYPE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/event-type']
+        - name: KONFLUX_COMPONENT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: PULL_REQUEST_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
+        - name: GIT_ORGANIZATION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/url-org']
+        - name: GIT_REPOSITORY
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/url-repository']
+        - name: SOURCE_REPO_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-repo-url']
+        - name: SOURCE_REPO_BRANCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-branch']
+        # This value refers to the target branch value in 'pull-request' events and branch value in 'push' events.
+        # E.g. for push event to 'main' branch this will have the value 'main'. For PR event that targets 'main' branch, this will be also 'main'.
+        - name: TARGET_REPO_BRANCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/branch']
+      script: |
+        #!/bin/bash
+
+        # Extract additional environment variables from SNAPSHOT
+        GIT_URL=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.url' <<< "$SNAPSHOT" 2>/dev/null || echo "")
+        GIT_REVISION=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "$SNAPSHOT" 2>/dev/null || echo "")
+        COMPONENT_CONTAINER_IMAGE=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT" 2>/dev/null || echo "")
+        SOURCE_REPO_ORG=$(echo "$SOURCE_REPO_URL" | sed -E 's#https://github.com/([^/]+)/.*#\1#')
+
+        # Validate required variables
+        if [[ -z "$KONFLUX_COMPONENT_NAME" ]]; then
+          echo "[ERROR] KONFLUX_COMPONENT_NAME is required but not found"
+          exit 1
+        fi
+
+        PR_AUTHOR="$(curl -s https://api.github.com/repos/${GIT_ORGANIZATION}/${GIT_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER} | jq -r .user.login 2>/dev/null || echo "")"
+
+        if [[ "$EVENT_TYPE" != "push" && -n "$PULL_REQUEST_NUMBER" ]]; then
+          EVENT_TYPE="pull_request"
+        elif [[ -z "$PULL_REQUEST_NUMBER" && "$EVENT_TYPE" != "push" ]]; then
+          EVENT_TYPE="push"
+        fi
+
+        JOB_SPEC=$(cat <<EOF
+        {
+            "container_image": "$COMPONENT_CONTAINER_IMAGE",
+            "konflux_component": "$KONFLUX_COMPONENT_NAME",
+            "snapshot": $SNAPSHOT,
+            "git": {
+                "pull_request_number": $PULL_REQUEST_NUMBER,
+                "pull_request_author": "$PR_AUTHOR",
+                "org": "$GIT_ORGANIZATION",
+                "repo": "$GIT_REPOSITORY",
+                "commit_sha": "$GIT_REVISION",
+                "event_type": "$EVENT_TYPE",
+                "source_repo_url": "$SOURCE_REPO_URL",
+                "source_repo_org": "$SOURCE_REPO_ORG",
+                "source_repo_branch": "$SOURCE_REPO_BRANCH",
+                "target_repo_branch": "$TARGET_REPO_BRANCH",
+                "url": "$GIT_URL",
+                "revision": "$GIT_REVISION"
+            }
+        }
+        EOF
+        )
+
+        echo "[INFO] Job spec:"
+        echo "$JOB_SPEC"
+
+        # Log the derived environment variables
+        echo "Integration Test metadata:"
+        echo "  SNAPSHOT: $SNAPSHOT"
+        echo "  EVENT_TYPE: $EVENT_TYPE"
+        echo "  KONFLUX_COMPONENT_NAME: $KONFLUX_COMPONENT_NAME"
+        echo "  PULL_REQUEST_NUMBER: $PULL_REQUEST_NUMBER"
+        echo "  GIT_ORGANIZATION: $GIT_ORGANIZATION"
+        echo "  GIT_REPOSITORY: $GIT_REPOSITORY"
+        echo "  GIT_URL: $GIT_URL"
+        echo "  GIT_REVISION: $GIT_REVISION"
+        echo "  PR_AUTHOR: $PR_AUTHOR"
+        echo "  COMPONENT_CONTAINER_IMAGE: $COMPONENT_CONTAINER_IMAGE"
+        echo "  SOURCE_REPO_URL: $SOURCE_REPO_URL"
+        echo "  SOURCE_REPO_BRANCH: $SOURCE_REPO_BRANCH"
+        echo "  TARGET_REPO_BRANCH: $TARGET_REPO_BRANCH"
+        echo "  SOURCE_REPO_ORG: $SOURCE_REPO_ORG"
+
+        # Write each environment variable to its respective result file (0.1 approach)
+        echo -n "$EVENT_TYPE" > $(results.test-event-type.path)
+        echo -n "$PULL_REQUEST_NUMBER" > $(results.pull-request-number.path)
+        echo -n "$GIT_ORGANIZATION" > $(results.git-org.path)
+        echo -n "$GIT_REPOSITORY" > $(results.git-repo.path)
+        echo -n "$COMPONENT_CONTAINER_IMAGE" > $(results.container-image.path)
+        echo -n "$GIT_URL" > $(results.git-url.path)
+        echo -n "$GIT_REVISION" > $(results.git-revision.path)
+        echo -n "$PR_AUTHOR" > $(results.pull-request-author.path)
+        echo -n "$JOB_SPEC" > $(results.job-spec.path)
+        echo -n "$SOURCE_REPO_URL" > $(results.source-repo-url.path)
+        echo -n "$SOURCE_REPO_BRANCH" > $(results.source-repo-branch.path)
+        echo -n "$TARGET_REPO_BRANCH" > $(results.target-repo-branch.path)
+        echo -n "$KONFLUX_COMPONENT_NAME" > $(results.component-name.path)
+
+        # Handle prefetch functionality (always enabled)
+        cosign download attestation "$COMPONENT_CONTAINER_IMAGE" > cosign_metadata.json 2>/dev/null || echo "{}" > cosign_metadata.json
+
+        CACHI2_SOURCE_ARTIFACT="$(jq -r \
+          '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+          select(.name == "prefetch-dependencies") | .results[] | select(.name == "CACHI2_ARTIFACT") | .value' \
+          cosign_metadata.json 2>/dev/null || echo "")"
+
+        SOURCE_ARTIFACT="$(jq -r \
+          '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+          select(.name == "prefetch-dependencies") | .results[] | select(.name == "SOURCE_ARTIFACT") | .value' \
+          cosign_metadata.json 2>/dev/null || echo "")"
+
+        # Check artifact status
+        if [[ -z "$CACHI2_SOURCE_ARTIFACT" || "$CACHI2_SOURCE_ARTIFACT" == "null" ]]; then
+          echo "[INFO] Cachi2 artifact: not found"
+          CACHI2_SOURCE_ARTIFACT=""
+        else
+          echo "[INFO] Cachi2 artifact: found ($CACHI2_SOURCE_ARTIFACT)"
+        fi
+
+        if [[ -z "$SOURCE_ARTIFACT" || "$SOURCE_ARTIFACT" == "null" ]]; then
+          echo "[INFO] Source artifact: not found"
+          SOURCE_ARTIFACT=""
+        else
+          echo "[INFO] Source artifact: found ($SOURCE_ARTIFACT)"
+        fi
+
+        # Extract repo and tag from image
+        IMAGE_WITHOUT_SHA="${COMPONENT_CONTAINER_IMAGE%%@sha256:*}"
+        CONTAINER_TAG="${IMAGE_WITHOUT_SHA##*:}"
+        CONTAINER_REPO="${IMAGE_WITHOUT_SHA%:*}"
+
+        # If tag is missing, default it based on event type
+        if [[ -z "$CONTAINER_TAG" ]]; then
+          if [[ "$EVENT_TYPE" == "pull_request" ]]; then
+            CONTAINER_TAG="on-pr-${GIT_REVISION}"
+          elif [[ "$EVENT_TYPE" == "push" ]]; then
+            CONTAINER_TAG="${GIT_REVISION}"
+          else
+            echo "[WARN] Unknown EVENT_TYPE: $EVENT_TYPE. Defaulting tag to revision."
+            CONTAINER_TAG="${GIT_REVISION}"
+          fi
+          echo "[INFO] No tag found, defaulting to: $CONTAINER_TAG"
+        fi
+
+        echo -n "$CACHI2_SOURCE_ARTIFACT" > $(results.prefetch-artifact.path)
+        echo -n "$SOURCE_ARTIFACT" > $(results.source-artifact.path)
+        echo -n "$CONTAINER_REPO" > $(results.container-repo.path)
+        echo -n "$CONTAINER_TAG" > $(results.container-tag.path)

--- a/tasks/test-metadata/0.3/test-metadata.yaml
+++ b/tasks/test-metadata/0.3/test-metadata.yaml
@@ -98,17 +98,16 @@ spec:
       script: |
         #!/bin/bash
 
+        if [[ -z "$KONFLUX_COMPONENT_NAME" ]]; then
+          echo "[ERROR] KONFLUX_COMPONENT_NAME is required but not found"
+          exit 1
+        fi
+
         # Extract additional environment variables from SNAPSHOT
         GIT_URL=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.url' <<< "$SNAPSHOT" 2>/dev/null || echo "")
         GIT_REVISION=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "$SNAPSHOT" 2>/dev/null || echo "")
         COMPONENT_CONTAINER_IMAGE=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT" 2>/dev/null || echo "")
         SOURCE_REPO_ORG=$(echo "$SOURCE_REPO_URL" | sed -E 's#https://github.com/([^/]+)/.*#\1#')
-
-        # Validate required variables
-        if [[ -z "$KONFLUX_COMPONENT_NAME" ]]; then
-          echo "[ERROR] KONFLUX_COMPONENT_NAME is required but not found"
-          exit 1
-        fi
 
         PR_AUTHOR="$(curl -s https://api.github.com/repos/${GIT_ORGANIZATION}/${GIT_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER} | jq -r .user.login 2>/dev/null || echo "")"
 
@@ -204,12 +203,22 @@ spec:
           echo "[INFO] Source artifact: found ($SOURCE_ARTIFACT)"
         fi
 
-        # Extract repo and tag from image
-        IMAGE_WITHOUT_SHA="${COMPONENT_CONTAINER_IMAGE%%@sha256:*}"
-        CONTAINER_TAG="${IMAGE_WITHOUT_SHA##*:}"
-        CONTAINER_REPO="${IMAGE_WITHOUT_SHA%:*}"
+        # Extract repo from image (handle both tag and digest formats)
+        if [[ "$COMPONENT_CONTAINER_IMAGE" == *"@"* ]]; then
+          # Image with digest (e.g., image@sha256:digest)
+          CONTAINER_REPO="${COMPONENT_CONTAINER_IMAGE%%@*}"
+          CONTAINER_TAG=""
+        elif [[ "$COMPONENT_CONTAINER_IMAGE" == *":"* ]]; then
+          # Image with tag (e.g., image:tag)
+          CONTAINER_REPO="${COMPONENT_CONTAINER_IMAGE%:*}"
+          CONTAINER_TAG="${COMPONENT_CONTAINER_IMAGE##*:}"
+        else
+          # Image without tag or digest
+          CONTAINER_REPO="$COMPONENT_CONTAINER_IMAGE"
+          CONTAINER_TAG=""
+        fi
 
-        # If tag is missing, default it based on event type
+        # Generate tag based on event type if not present
         if [[ -z "$CONTAINER_TAG" ]]; then
           if [[ "$EVENT_TYPE" == "pull_request" ]]; then
             CONTAINER_TAG="on-pr-${GIT_REVISION}"


### PR DESCRIPTION
Adds test-metadata v0.3 that combines functionality from v0.1 and v0.2 with new container parsing capabilities.
Key additions:

* Individual results (v0.1) + consolidated job-spec (v0.2)
* Prefetch artifacts (CACHI2 and SOURCE) from build container
* Container repository and tag extraction
* Enhanced error handling and logging
