### PR TITLE
fix: keep pairing only for "release" components

### DIFF
--- a/scripts/konflux-ci-deploy/solve-pr-pairing.sh
+++ b/scripts/konflux-ci-deploy/solve-pr-pairing.sh
@@ -17,9 +17,18 @@ set -euo pipefail
 # -----------------------------------------------------------------------------------
 
 COMPONENT_NAME="${COMPONENT_NAME:-}"
+EVENT_TYPE="${EVENT_TYPE:-}"
 PR_SOURCE_BRANCH="${PR_SOURCE_BRANCH:-}"
 PR_AUTHOR="${PR_AUTHOR:-}"
 PR_SHA="${PR_SHA:-}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+
+if [[ "$EVENT_TYPE" == "push" ]]; then
+  IMAGE_TAG="${IMAGE_TAG:=$PR_SHA}"
+  PR_AUTHOR="konflux-ci"
+else
+  IMAGE_TAG="${IMAGE_TAG:=on-pr-$PR_SHA}"
+fi
 
 RELEASE_SERVICE_REPO="konflux-ci/release-service"
 INFRA_DEPLOYMENTS_REPO="redhat-appstudio/infra-deployments"
@@ -57,22 +66,6 @@ download_file() {
   log "Downloaded $(basename "$dest")"
 }
 
-IMAGE_TAG="on-pr-$PR_SHA"
-if [[ -z "$PR_AUTHOR" ]]; then
-  IMAGE_TAG=$PR_SHA
-  PR_AUTHOR=konflux-ci
-fi
-
-konflux_components=( build-service integration-service image-controller release-service)
-
-for component in "${konflux_components[@]}"; do
-  if [[ "$COMPONENT_NAME" == "$component" ]]; then
-    log "Setting up env vars for '$component'"
-    write_env_file "$IMAGE_TAG" "$PR_SHA"
-    cat "$ENV_FILE"
-  fi
-done
-
 if [[ "$COMPONENT_NAME" == "release-service-catalog" || "$COMPONENT_NAME" == "release-service" ]]; then
   if [[ "$COMPONENT_NAME" == "release-service-catalog" ]]; then
     log "Looking for paired PR in $RELEASE_SERVICE_REPO for 'release-service-catalog'"
@@ -85,6 +78,10 @@ if [[ "$COMPONENT_NAME" == "release-service-catalog" || "$COMPONENT_NAME" == "re
     else
       log "No paired PR found in $RELEASE_SERVICE_REPO by $PR_AUTHOR on branch $PR_SOURCE_BRANCH"
     fi
+  elif [[ "$COMPONENT_NAME" == "release-service" ]]; then
+    log "Setting up env vars for '$COMPONENT_NAME'"
+    write_env_file "$IMAGE_TAG" "$PR_SHA"
+    cat "$ENV_FILE"
   fi
 
   log "Checking for paired PR in $INFRA_DEPLOYMENTS_REPO"

--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -115,8 +115,14 @@ spec:
           operator: notin
           values: [ "" ]
       env:
+        - name: EVENT_TYPE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/event-type']
         - name: COMPONENT_NAME
           value: "$(params.component-name)"
+        - name: IMAGE_TAG
+          value: "$(params.component-image-tag)"
         - name: PR_SOURCE_BRANCH
           value: "$(params.component-pr-source-branch)"
         - name: PR_AUTHOR


### PR DESCRIPTION
[previous PR](https://github.com/konflux-ci/tekton-integration-catalog/pull/198) fixed the pairing script for periodic jobs for release-service, but caused an issue in other konflux-ci components

those component shouldn't use pairing script but rather use [test-metadata v0.3](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/test-metadata/0.3) which generates all required data

This PR also passes $EVENT_TYPE env var to the pr-pairing to determine the container image tag based on the push/pull event.

It also fixes an issue where the IMAGE_TAG extracted from the sealights-ref Task was overriden in the pr-pairing script which led to the test deploying an image which did not contain sealights instrumentation