### PR TITLE
docs: amend version in deploy-konflux-ci readme

### DIFF
--- a/tasks/konflux-ci/deploy/0.3/Readme.md
+++ b/tasks/konflux-ci/deploy/0.3/Readme.md
@@ -1,6 +1,6 @@
 # 🚀 Tekton Task: `deploy-konflux-ci`
 
-Version: 0.2
+Version: 0.3
 
 This task automates the deployment of [Konflux CI](https://github.com/konflux-ci/konflux-ci) into a Kubernetes or OpenShift environment.
 It is tailored for use within OpenShift Pipelines (Tekton) and supports full setup, including dependencies, policies, and test resources.


### PR DESCRIPTION
fixes version string in the readme of the version-3 `deploy-konflux-ci` task, from `0.2` to `0.3`.