### PR TITLE
fix: container image ref format

### DIFF
--- a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
+++ b/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
@@ -70,6 +70,13 @@ spec:
         # Download cosign attestation metadata
         cosign download attestation "${COMPONENT_CONTAINER_IMAGE}" > cosign_metadata.json
 
+         # Set the container image ref to a format quay.io/<org>/<repo>:<tag>@sha256:<sha256-value>
+        COMPONENT_CONTAINER_IMAGE="$(jq -r '
+            .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+            select(.ref.params[].value == "build-image-index") |
+            .results[] | select(.name == "IMAGE_REF") | .value
+          ' cosign_metadata.json)"
+
         COMPONENT_SOURCE_ARTIFACT="$(jq -r '
           .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
           select(.name == "clone-repository") |


### PR DESCRIPTION
### Description
This PR fixes an issue when the build pipeline contains the multiarch build Task, which is not supported by sealights-get-refs Task, i.e. the sealights image extraction does not work and in that case and the image extraction falls back to the container image from the snapshot.

But since the image ref format extracted from the snapshot is 

`quay.io/<org>/<repo>sha256:<sha256-value>` and not 

`quay.io/<org>/<repo>:<tag>@sha256:<sha256-value>`

like it is expected [here](https://github.com/konflux-ci/tekton-integration-catalog/blob/822c22bf876294ff71f3f7d7dd2ededd6050a35a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml#L123), the container image tag is evaluated wrong and results in this value of image tag:

<img width="1000" height="632" alt="Screenshot 2025-08-11 at 16 13 34" src="https://github.com/user-attachments/assets/099e75a5-fdc4-4e6c-8b6a-bbf5e9199ac6" />


So this PR extracts the container image ref in expected format (`quay.io/<org>/<repo>:<tag>@sha256:<sha256-value>`), which fixes the mentioned issue.

### Verification
tested with [this PR](https://github.com/konflux-ci/release-service/pull/807)