### PR TITLE
feat: add Checkton tekton task to linting tasks

### DIFF
--- a/tasks/linters/checkton/0.1/README.md
+++ b/tasks/linters/checkton/0.1/README.md
@@ -1,0 +1,64 @@
+# Checkton Task
+
+## Description
+
+The Checkton task runs Shellcheck on scripts embedded in YAML files.  For more information see https://github.com/chmeliik/checkton/
+
+## Usage
+
+To integration Checkton into your Tekton pipeline, follow these  steps:
+
+1. **Define Parameters**: Specify the Git URL and revision (commit SHA) of the repository containing your shell scripts.
+
+2. **Task Integration**: Integrate the `checkton` task into your Tekton pipeline definition.
+
+3. **Execution**: During pipeline execution, the `checkton` task will clone the specified Git repository, search for yaml files in it, and analyze the shell scripts
+found within those yaml files using it using ShellCheck.
+
+4. **Results**: Any issues detected during analysis will be reported as pipeline output, enabling you to identify and address potential problems in your shell scripts.
+
+## Example
+
+Example usage of the `checkton` task in a Tekton Pipeline:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: linter-pipeline-example
+spec:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test-metadata/0.1/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: oras-container
+          value: $(params.oras-container)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+    - name: checkton
+      runAfter:
+        - test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/linters/checkton/0.1/checkton.yaml
+      params:
+        - name: git-url
+          value: "$(tasks.test-metadata.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.test-metadata.results.git-revision)"
+```

--- a/tasks/linters/checkton/0.1/checkton.yaml
+++ b/tasks/linters/checkton/0.1/checkton.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: checkton
+spec:
+    params:
+    - name: git-url
+      description: The Git URL from which the test pipeline is originating. This can be from a fork or the original repository.
+      type: string
+    - name: git-revision
+      description: The Git revision (commit SHA) from which the test pipeline is originating.
+      type: string
+    - name: exclude-dirs
+      description: A list of files or directories to exclude from the ShellCheck analysis.
+      type: array
+      default: []
+    - name: checkton-repo
+      type: string
+      default: chmeliik/checkton
+      description: name of github repo with checkton script, formatted as "org/name"
+    - name: checkton-repo-branch
+      type: string
+      default: main
+      description: name of branch within checkton repo from which to pull file
+    steps:
+    - name: clone-refs
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      workingDir: /workspace
+      script: |
+        #!/bin/sh
+        set -e
+
+        git clone "$(params.git-url)" .
+        git checkout "$(params.git-revision)"
+    - name: run-checkton
+      image: ghcr.io/chmeliik/checkton:v0.4.0
+      workingDir: /workspace
+


### PR DESCRIPTION
The integration service is now using Checkton to test code changes. Since shellcheck is also stored in tekton-integration-catalog and checkton fulfills a similar purpose, it makes sense to also include Checkton in the catalog