### PR TITLE
feat: add OCI artifact viewer

### DIFF
--- a/tasks/pull-request-comment/0.1/README.md
+++ b/tasks/pull-request-comment/0.1/README.md
@@ -20,6 +20,7 @@ Pull Request Commenter Task posts a comment on a GitHub pull request summarizing
 | e2e-log-name | The name of the log file from end-to-end tests. | e2e-tests.log | ✅ |
 | cluster-provision-log-name | The name of the log file from cluster provisioning. | cluster-provision.log | ✅ |
 | enable-test-results-analysis | Set to `true` to enable experimental test results analysis. | false | ❌ |
+| artifact-browser-url | Provides the URL to the artifact browser deployment. | "" | ❌ |
 
 ## Behavior
 
@@ -31,6 +32,7 @@ Pull Request Commenter Task posts a comment on a GitHub pull request summarizing
   - Instructions to rerun tests.
   - Steps to retrieve artifacts using ORAS.
   - Optional test results analysis if enabled.
+  - Optional OCI artifact browser link to related OCI artifact.
 
 ## Usage
 

--- a/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.1/pull-request-comment.yaml
@@ -56,6 +56,10 @@ spec:
       type: string
       default: "false"
       description: Add "true" if you want to enable experimental test analysis step
+    - name: artifact-browser-url
+      type: string
+      default: ""
+      description: Provides the URL to the artifact browser deployment.
   volumes:
     - name: konflux-test-infra-volume
       secret:
@@ -168,6 +172,16 @@ spec:
         # Store the content of the test results analysis (from a previous step) in a variable
         TEST_RESULTS_ANALYSIS=$(cat analysis.md || echo "\<not enabled\>")
 
+        # Generate artifact browser link if URL is provided
+        ARTIFACT_BROWSER_URL=$(echo "\<not enabled\>")
+        if [ -n "$(params.artifact-browser-url)" ]; then
+            # Use the provided artifact browser URL
+            export ARTIFACT_BROWSER_BASE_URL="$(params.artifact-browser-url)"
+            # Extract repository name from OCI container reference
+            REPO_NAME=$(echo "$OCI_STORAGE_CONTAINER" | sed 's|.*/||' | sed 's|:.*||')
+            ARTIFACT_BROWSER_URL="[View in Artifact Browser](${ARTIFACT_BROWSER_BASE_URL}/${REPO_NAME}/${TEST_NAME}/)"
+        fi
+        
         PR_COMMENT=$(cat <<EOF
         @${PR_AUTHOR}: The following test has ${PIPELINE_RUN_AGGREGATE_STATUS}, say **/retest** to rerun failed tests.
 
@@ -187,6 +201,8 @@ spec:
         \`\`\`
         ### Test results analysis
         ${TEST_RESULTS_ANALYSIS}
+        ### OCI Artifact Browser URL
+        ${ARTIFACT_BROWSER_URL}
         EOF
         )
         # Combine body components into the final JSON body

--- a/tasks/pull-request-comment/0.2/README.md
+++ b/tasks/pull-request-comment/0.2/README.md
@@ -25,6 +25,7 @@ The **Pull Request Commenter Task** automatically posts a comment on a GitHub pu
 | `junit-report-name` | JUnit file report name for analysis. | `junit.xml` | ✅ Yes |
 | `e2e-log-name` | The name of the log file from end-to-end tests. | `e2e-tests.log` | ✅ Yes |
 | `cluster-provision-log-name` | The name of the log file from cluster provisioning. | `cluster-provision.log` | ✅ Yes |
+| `artifact-browser-url` | Provides the URL to the artifact browser deployment. | "" | ❌ No |
 
 ## Results
 
@@ -49,6 +50,12 @@ To enable the experimental **Test Results Analysis**, set `enable-test-results-a
 - Scan logs and reports stored in the specified OCI artifact.
 - Identify potential causes of test failures.
 - Append the analysis summary to the PR comment.
+
+## Enabling OCI Artifact Browser
+
+To enable the **OCI Artifact Browser**, provide the artifact browser deployment URL via the `artifact-browser-url` parameter. When a URL is provided, the task will generate a direct link to the specific test artifacts in the PR comment.
+
+If the parameter is empty or not provided, no artifact browser link will be included in the comment.
 
 ## Additional Notes
 

--- a/tasks/pull-request-comment/0.2/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.2/pull-request-comment.yaml
@@ -44,6 +44,10 @@ spec:
       type: string
       default: "false"
       description: Add "true" if you want to enable experimental test analysis step
+    - name: artifact-browser-url
+      type: string
+      default: ""
+      description: Provides the URL to the artifact browser deployment.
   volumes:
     - name: konflux-test-infra-volume
       secret:
@@ -150,6 +154,16 @@ spec:
         # Store the content of the test results analysis (from a previous step) in a variable
         TEST_RESULTS_ANALYSIS=$(cat analysis.md || echo "\<not enabled\>")
 
+        # Generate artifact browser link if URL is provided
+        ARTIFACT_BROWSER_URL=$(echo "\<not enabled\>")
+        if [ -n "$(params.artifact-browser-url)" ]; then
+            # Use the provided artifact browser URL
+            export ARTIFACT_BROWSER_BASE_URL="$(params.artifact-browser-url)"
+            # Extract repository name from OCI container reference
+            REPO_NAME=$(echo "$OCI_STORAGE_CONTAINER" | sed 's|.*/||' | sed 's|:.*||')
+            ARTIFACT_BROWSER_URL="[View in Artifact Browser](${ARTIFACT_BROWSER_BASE_URL}/${REPO_NAME}/${TEST_NAME}/)"
+        fi
+
         PR_COMMENT=$(cat <<EOF
         @${PR_AUTHOR}: The following test has ${PIPELINE_RUN_AGGREGATE_STATUS}, say **/retest** to rerun failed tests.
 
@@ -169,6 +183,8 @@ spec:
         \`\`\`
         ### Test results analysis
         ${TEST_RESULTS_ANALYSIS}
+        ### OCI Artifact Browser URL
+        ${ARTIFACT_BROWSER_URL}
         EOF
         )
         # Combine body components into the final JSON body


### PR DESCRIPTION
Update pull-request-comment Task to add a link to the OCI artifact browser with the path to the related OCI artifact. After konflux-ci pipeline fails, a link to the artifact browser is added to the PR comment that will redirect user to the correct artifact.