### PR TITLE
fix: bump mapt version, fix provision task logging

### DIFF
--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
@@ -144,7 +144,7 @@ spec:
           values: ["Succeeded"]
 
     - name: destroy
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.9.7
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
@@ -114,7 +114,7 @@ spec:
 
   steps:
     - name: provisioner
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.9.7
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -97,6 +97,11 @@ spec:
       description: |
         Adds a percentage to the base spot price to improve chances of getting the instance.
       default: '20'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
     - name: version
       description: |
         The desired Kubernetes version for the Kind cluster. If left blank, the latest stable version will be used.
@@ -208,7 +213,7 @@ spec:
         if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
         if [[ $(params.version) != "" ]]; then cmd+="--version $(params.version) "; fi
         if [[ $(params.spot) == "true" ]]; then
-          cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) "
+          cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) "
         fi
         if [[ $(params.timeout) != "" ]]; then cmd+="--timeout $(params.timeout) "; fi
         cmd+="--tags $(params.tags) "

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -218,9 +218,9 @@ spec:
         if [[ $(params.timeout) != "" ]]; then cmd+="--timeout $(params.timeout) "; fi
         cmd+="--tags $(params.tags) "
 
-        output=$(eval "${cmd}" 2>&1)
-        exit_code=$?
-        echo "${output}" | tee $LOG_FILENAME
+        eval "${cmd}" 2>&1 | tee "$LOG_FILENAME"
+        exit_code="${PIPESTATUS[0]}"
+        echo "[INFO] cluster provisioning finished with exit code $exit_code"
         exit $exit_code
 
       computeResources:

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -181,7 +181,7 @@ spec:
 
     - name: provisioner
       onError: continue
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.9.7
       volumeMounts:
         - name: aws-credentials
           mountPath: /opt/aws-credentials


### PR DESCRIPTION
### Description
* bump version of mapt to v0.9.7
* add `spot-eviction-tolerance` param
* fix logging issue

### Verification
verified with
* https://github.com/konflux-ci/e2e-tests/pull/1656/commits/aff3f87d6b75862f12706a50158774ee3fbf06a6
* https://github.com/konflux-ci/image-controller/pull/213/commits/4e1f4195640815c40999e1902a3487fb024b0e5d#diff-642a5657e437b7abe9d81849a1ec198ee32c73420ab078e75ed87f9c4158af1aR88