### PR TITLE
fix(KONFLUX-9907): fix mirror lookup logic

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -306,32 +306,47 @@ spec:
 
               echo "Image Mirror Map found:"
               cat /tekton/home/mirror-map.txt
+              echo
 
               # Get registry and repo (without digest or tag)
               reg_and_repo=$(get_image_registry_and_repository "${BUNDLE_IMAGE}")
 
-              # Look up the *original* image for which this is a mirror
-              upstream_image=$(jq -r --arg mirror "${reg_and_repo}" '
-                to_entries[] | select(.value[] == $mirror) | .key' /tekton/home/mirror-map.txt)
+              #  Look up mirrors for this upstream image
+              mirrors=$(jq -r --arg source "${reg_and_repo}" '.[$source][]?' /tekton/home/mirror-map.txt)
 
-              if [[ -n "$upstream_image" ]]; then
-                echo "Upstream image mapped to $reg_and_repo is $upstream_image"
-                
-                replaced_image=$(replace_image_pullspec "$BUNDLE_IMAGE" "$upstream_image")
+              if [[ -n "$mirrors" ]]; then
+                echo "Found mirrors for $reg_and_repo:"
+                echo "$mirrors"
+                echo
 
-                echo "Attempting to inspect upstream image: $replaced_image"
-                if skopeo inspect --no-tags --config "docker://${replaced_image}" > /dev/null 2>&1; then
-                  echo "Successfully using upstream image $replaced_image"
-                else
-                  echo "Mapped upstream image $replaced_image is inaccessible"
+                mirror_found=0
+
+                for mirror in $mirrors; do
+                  replaced_image=$(replace_image_pullspec "$BUNDLE_IMAGE" "$mirror")
+                  echo "Attempting to inspect mirror image: $replaced_image"
+
+                  if skopeo inspect --no-tags --config "docker://${replaced_image}" > /dev/null 2>&1; then
+                    echo "Successfully using mirror image $replaced_image"
+                    mirror_found=1
+
+                    # Write the selected mirror to Tekton result
+                    echo -n "$replaced_image" > "$(results.unreleasedBundle.path)"
+
+                    break
+                  else
+                    echo "Mirror image $replaced_image is inaccessible, trying next..."
+                    echo
+                  fi
+                done
+
+                if [[ $mirror_found -eq 0 ]]; then
+                  echo "No working mirrors found for $reg_and_repo"
                   exit 1
                 fi
               else
-                echo "No upstream mirror found for $reg_and_repo in mirror map."
+                echo "No mirrors listed for $reg_and_repo in mirror map."
                 exit 1
               fi
-
-              echo -n "$replaced_image" > "$(results.unreleasedBundle.path)"
     - name: pick-cluster-params
       runAfter:
         - get-unreleased-bundle


### PR DESCRIPTION
There is a bug in the mirror lookup logic:
- The script tries to find the upstream image by checking whether the current BUNDLE_IMAGE appeared in the values of the mirror map (.value[]). But BUNDLE_IMAGE was always the upstream (a key in the map), not a mirror.
As a result, the lookup always failed with:
`No upstream mirror found for registry.redhat.io/... in mirror map.`

Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1756302636361019

IDMS: https://github.com/openshift/lightspeed-operator/blob/main/config/manager/imagedigestmirrorset.yaml

Testing output:
```
Could not inspect original pullspec registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:e546394316e9dc745442894482fd233f31b3bb64260dabd2204c56ccc08d1274. Checking if there's a mirror present
Image Mirror Map found:
{"registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator":["registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rhel9-operator","quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator"],"registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle":["registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle","quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle"],"registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9":["registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-service-api-rhel9","quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service"],"registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9":["registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-rhel9","quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console"]}

Found mirrors for registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle:
registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle
quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle

Attempting to inspect mirror image: registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle@sha256:e546394316e9dc745442894482fd233f31b3bb64260dabd2204c56ccc08d1274
Mirror image registry.staging.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle@sha256:e546394316e9dc745442894482fd233f31b3bb64260dabd2204c56ccc08d1274 is inaccessible, trying next...

Attempting to inspect mirror image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle@sha256:e546394316e9dc745442894482fd233f31b3bb64260dabd2204c56ccc08d1274
Mirror image quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle@sha256:e546394316e9dc745442894482fd233f31b3bb64260dabd2204c56ccc08d1274 is inaccessible, trying next...

No working mirrors found for registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle
```