### PR TITLE
fix: add imagerepositories also in artifacts

### DIFF
--- a/scripts/gather-extra.sh
+++ b/scripts/gather-extra.sh
@@ -98,6 +98,7 @@ queue ${ARTIFACT_DIR}/spiaccesstokendataupdates.json  oc --insecure-skip-tls-ver
 queue ${ARTIFACT_DIR}/spiaccesstokens.json  oc --insecure-skip-tls-verify --request-timeout=5s get spiaccesstokens.appstudio.redhat.com --all-namespaces -o json
 queue ${ARTIFACT_DIR}/spifilecontentrequests.json  oc --insecure-skip-tls-verify --request-timeout=5s get spifilecontentrequests.appstudio.redhat.com --all-namespaces -o json
 queue ${ARTIFACT_DIR}/remotesecrets.json oc --insecure-skip-tls-verify --request-timeout=5s get remotesecrets.appstudio.redhat.com --all-namespaces -o json
+queue ${ARTIFACT_DIR}/imagerepositories.json  oc --insecure-skip-tls-verify --request-timeout=5s get imagerepositories.components.appstudio.redhat.com --all-namespaces -o json
 
 # JBS resources (jvm-build-service)
 queue ${ARTIFACT_DIR}/artifactbuilds.json  oc --insecure-skip-tls-verify --request-timeout=5s get artifactbuilds.jvmbuildservice.io --all-namespaces -o json

--- a/scripts/gather-extra.sh
+++ b/scripts/gather-extra.sh
@@ -98,7 +98,7 @@ queue ${ARTIFACT_DIR}/spiaccesstokendataupdates.json  oc --insecure-skip-tls-ver
 queue ${ARTIFACT_DIR}/spiaccesstokens.json  oc --insecure-skip-tls-verify --request-timeout=5s get spiaccesstokens.appstudio.redhat.com --all-namespaces -o json
 queue ${ARTIFACT_DIR}/spifilecontentrequests.json  oc --insecure-skip-tls-verify --request-timeout=5s get spifilecontentrequests.appstudio.redhat.com --all-namespaces -o json
 queue ${ARTIFACT_DIR}/remotesecrets.json oc --insecure-skip-tls-verify --request-timeout=5s get remotesecrets.appstudio.redhat.com --all-namespaces -o json
-queue ${ARTIFACT_DIR}/imagerepositories.json  oc --insecure-skip-tls-verify --request-timeout=5s get imagerepositories.components.appstudio.redhat.com --all-namespaces -o json
+queue ${ARTIFACT_DIR}/imagerepositories.json  oc --insecure-skip-tls-verify --request-timeout=5s get imagerepositories.appstudio.redhat.com --all-namespaces -o json
 
 # JBS resources (jvm-build-service)
 queue ${ARTIFACT_DIR}/artifactbuilds.json  oc --insecure-skip-tls-verify --request-timeout=5s get artifactbuilds.jvmbuildservice.io --all-namespaces -o json


### PR DESCRIPTION
This PR includes imagerepositories in the artifacts after the test execution (if fails) to help debug failures.