### PR TITLE
refactor: extract kind-aws-spot inline steps into StepActions

### DIFF
--- a/stepactions/create-kubeconfig-secret/0.1/README.md
+++ b/stepactions/create-kubeconfig-secret/0.1/README.md
@@ -1,0 +1,50 @@
+# create-kubeconfig-secret stepaction
+
+Creates an empty Kubernetes Secret with an owner reference to a PipelineRun or TaskRun.
+The secret is intended to store a kubeconfig that will be populated by a subsequent step
+(e.g. `update-kubeconfig-secret`). Deleting the owning resource automatically garbage-collects the secret.
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|secret-name|The name to assign to the Kubernetes Secret||true|
+|namespace|The namespace where the Secret will be created||true|
+|ownerKind|The Tekton resource type owning this Secret (`PipelineRun` or `TaskRun`)|PipelineRun|false|
+|ownerName|The name of the owning PipelineRun or TaskRun||true|
+|ownerUid|The UID of the owning PipelineRun or TaskRun||true|
+
+## Results
+
+|name|description|
+|---|---|
+|secret-name|The name of the created kubeconfig Secret (echoed back from the input param)|
+
+## Example Usage
+
+```yaml
+steps:
+  - name: create-kubeconfig-secret
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/create-kubeconfig-secret/0.1/create-kubeconfig-secret.yaml
+    params:
+      - name: secret-name
+        value: $(params.cluster-access-secret-name)
+      - name: namespace
+        value: $(context.taskRun.namespace)
+      - name: ownerKind
+        value: $(params.ownerKind)
+      - name: ownerName
+        value: $(params.ownerName)
+      - name: ownerUid
+        value: $(params.ownerUid)
+```
+
+### Suitable for upstream communities

--- a/stepactions/create-kubeconfig-secret/0.1/create-kubeconfig-secret.yaml
+++ b/stepactions/create-kubeconfig-secret/0.1/create-kubeconfig-secret.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: create-kubeconfig-secret
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, kubernetes
+    tekton.dev/displayName: "Create Kubeconfig Secret"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    Creates an empty Kubernetes Secret with an owner reference to a PipelineRun or TaskRun.
+    The secret is intended to store a kubeconfig and will be populated by a subsequent step.
+  image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+  results:
+    - name: secret-name
+      description: The name of the created kubeconfig Secret.
+  params:
+    - name: secret-name
+      type: string
+      description: The name to assign to the Kubernetes Secret.
+    - name: namespace
+      type: string
+      description: The namespace where the Secret will be created.
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: The Tekton resource type owning this Secret (PipelineRun or TaskRun).
+    - name: ownerName
+      type: string
+      description: The name of the owning PipelineRun or TaskRun.
+    - name: ownerUid
+      type: string
+      description: The UID of the owning PipelineRun or TaskRun.
+  env:
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: SECRET_NAME
+      value: $(params.secret-name)
+    - name: OWNER_KIND
+      value: $(params.ownerKind)
+    - name: OWNER_NAME
+      value: $(params.ownerName)
+    - name: OWNER_UID
+      value: $(params.ownerUid)
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+
+    echo "[INFO] Creating secret: $SECRET_NAME"
+
+    cat <<EOF | oc create -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${SECRET_NAME}
+      namespace: ${NAMESPACE}
+      ownerReferences:
+      - apiVersion: tekton.dev/v1
+        kind: ${OWNER_KIND}
+        name: ${OWNER_NAME}
+        uid: ${OWNER_UID}
+    type: Opaque
+    data:
+      kubeconfig: ""
+    EOF
+
+    echo "[INFO] Successfully created secret: $SECRET_NAME"
+    echo -n "${SECRET_NAME}" | tee "$(step.results.secret-name.path)"

--- a/stepactions/create-ssh-credentials-secret/0.1/README.md
+++ b/stepactions/create-ssh-credentials-secret/0.1/README.md
@@ -1,0 +1,51 @@
+# create-ssh-credentials-secret stepaction
+
+Creates an empty Kubernetes Secret with an owner reference, intended to store SSH credentials
+(`host`, `username`, `id_rsa`) for a provisioned VM. The data fields will be populated by a
+subsequent step (e.g. `update-ssh-credentials-secret`). If `secret-name` is empty, the step
+is skipped and the result is set to an empty string.
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|secret-name|The name to assign to the Kubernetes Secret. If empty, the step is skipped.|""|false|
+|namespace|The namespace where the Secret will be created||true|
+|ownerKind|The Tekton resource type owning this Secret (`PipelineRun` or `TaskRun`)|PipelineRun|false|
+|ownerName|The name of the owning PipelineRun or TaskRun||true|
+|ownerUid|The UID of the owning PipelineRun or TaskRun||true|
+
+## Results
+
+|name|description|
+|---|---|
+|secret-name|The name of the created SSH credentials Secret, or empty if the step was skipped|
+
+## Example Usage
+
+```yaml
+steps:
+  - name: create-ssh-credentials-secret
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/create-ssh-credentials-secret/0.1/create-ssh-credentials-secret.yaml
+    params:
+      - name: secret-name
+        value: $(params.ssh-credentials-secret-name)
+      - name: namespace
+        value: $(context.taskRun.namespace)
+      - name: ownerKind
+        value: $(params.ownerKind)
+      - name: ownerName
+        value: $(params.ownerName)
+      - name: ownerUid
+        value: $(params.ownerUid)
+```
+
+### Suitable for upstream communities

--- a/stepactions/create-ssh-credentials-secret/0.1/create-ssh-credentials-secret.yaml
+++ b/stepactions/create-ssh-credentials-secret/0.1/create-ssh-credentials-secret.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: create-ssh-credentials-secret
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, kubernetes
+    tekton.dev/displayName: "Create SSH Credentials Secret"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    Creates an empty Kubernetes Secret with an owner reference, intended to store SSH
+    credentials (host, username, id_rsa) to be populated by a subsequent step.
+    If secret-name is empty, the step is skipped and the result is set to an empty string.
+  image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+  results:
+    - name: secret-name
+      description: The name of the created SSH credentials Secret, or empty if skipped.
+  params:
+    - name: secret-name
+      type: string
+      default: ""
+      description: |
+        The name to assign to the Kubernetes Secret. If left empty, the step is skipped
+        and no secret is created.
+    - name: namespace
+      type: string
+      description: The namespace where the Secret will be created.
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: The Tekton resource type owning this Secret (PipelineRun or TaskRun).
+    - name: ownerName
+      type: string
+      description: The name of the owning PipelineRun or TaskRun.
+    - name: ownerUid
+      type: string
+      description: The UID of the owning PipelineRun or TaskRun.
+  env:
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: SSH_SECRET_NAME
+      value: $(params.secret-name)
+    - name: OWNER_KIND
+      value: $(params.ownerKind)
+    - name: OWNER_NAME
+      value: $(params.ownerName)
+    - name: OWNER_UID
+      value: $(params.ownerUid)
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+
+    if [[ -z "$SSH_SECRET_NAME" ]]; then
+      echo "[INFO] No SSH credentials secret requested, skipping."
+      echo -n "" | tee "$(step.results.secret-name.path)"
+      exit 0
+    fi
+
+    echo "[INFO] Creating SSH credentials secret: $SSH_SECRET_NAME"
+
+    cat <<EOF | oc create -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${SSH_SECRET_NAME}
+      namespace: ${NAMESPACE}
+      ownerReferences:
+      - apiVersion: tekton.dev/v1
+        kind: ${OWNER_KIND}
+        name: ${OWNER_NAME}
+        uid: ${OWNER_UID}
+    type: Opaque
+    data:
+      host: ""
+      username: ""
+      id_rsa: ""
+    EOF
+
+    echo "[INFO] Successfully created secret: $SSH_SECRET_NAME"
+    echo -n "${SSH_SECRET_NAME}" | tee "$(step.results.secret-name.path)"

--- a/stepactions/kind-aws-destroy/0.1/README.md
+++ b/stepactions/kind-aws-destroy/0.1/README.md
@@ -1,0 +1,45 @@
+# kind-aws-destroy stepaction
+
+Destroys a Kind cluster previously provisioned on AWS using the [Mapt CLI](https://github.com/redhat-developer/mapt).
+The `id` must match the one used during provisioning so the operation is scoped to the correct environment.
+
+The parent Task must declare a Secret-backed volume for AWS credentials (referenced via `aws-credentials-volume`).
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|aws-credentials-volume|Name of the volume that mounts the AWS credentials secret||true|
+|id|The unique identifier of the Kind environment to destroy. Must match the ID used during provisioning||true|
+|debug|Enables verbose logging. May expose credentials — use only in secure environments|false|false|
+|force-destroy|Destroy even if there is a provisioning lock on the stack|true|false|
+
+## Example Usage
+
+```yaml
+volumes:
+  - name: aws-credentials
+    secret:
+      secretName: $(params.secret-aws-credentials)
+
+steps:
+  - name: destroy
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/kind-aws-destroy/0.1/kind-aws-destroy.yaml
+    params:
+      - name: aws-credentials-volume
+        value: aws-credentials
+      - name: id
+        value: $(params.id)
+      - name: force-destroy
+        value: $(params.force-destroy)
+```
+
+### Suitable for upstream communities

--- a/stepactions/kind-aws-destroy/0.1/kind-aws-destroy.yaml
+++ b/stepactions/kind-aws-destroy/0.1/kind-aws-destroy.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: kind-aws-destroy
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, kind
+    tekton.dev/displayName: "Kind on AWS - Destroy"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+    mapt/version: "v0.9.9"
+spec:
+  description: |
+    Destroys a Kind cluster previously provisioned on AWS using the Mapt CLI.
+    Matches the environment ID used during provisioning to scope the cleanup operation.
+  image: quay.io/redhat-developer/mapt:v0.9.9
+  params:
+    - name: aws-credentials-volume
+      type: string
+      description: Name of the volume that mounts the AWS credentials secret.
+    - name: id
+      type: string
+      description: The unique identifier of the Kind environment to destroy. Must match the ID used during provisioning.
+    - name: debug
+      type: string
+      default: 'false'
+      description: Enables verbose logging. May expose credentials — use only in secure environments.
+    - name: force-destroy
+      type: string
+      default: 'true'
+      description: Destroy even if there is a provisioning lock on the stack.
+  volumeMounts:
+    - name: $(params.aws-credentials-volume)
+      mountPath: /opt/aws-credentials
+  computeResources:
+    requests:
+      memory: "200Mi"
+      cpu: "100m"
+    limits:
+      memory: "600Mi"
+      cpu: "300m"
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+    if [[ "$(params.debug)" == "true" ]]; then set -xeuo pipefail; fi
+
+    AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
+    export AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
+    export AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
+    export AWS_DEFAULT_REGION
+    BUCKET=$(cat /opt/aws-credentials/bucket)
+
+    cmd=(mapt aws kind destroy
+      --project-name "kind-$(params.id)"
+      --backed-url "s3://${BUCKET}/mapt/kind/$(params.id)"
+    )
+
+    if [[ "$(params.force-destroy)" == "true" ]]; then
+      cmd+=(--force-destroy)
+    fi
+
+    "${cmd[@]}"

--- a/stepactions/kind-aws-provisioner/0.1/README.md
+++ b/stepactions/kind-aws-provisioner/0.1/README.md
@@ -1,0 +1,67 @@
+# kind-aws-provisioner stepaction
+
+Provisions a single-node Kind cluster on AWS using the [Mapt CLI](https://github.com/redhat-developer/mapt).
+On success, connection details (`kubeconfig`, `host`, `username`, `id_rsa`) are written to the
+directory mounted by `cluster-info-volume`.
+
+If the `LOG_FILENAME` environment variable is set (e.g. injected via a Task `stepTemplate`),
+command output is also tee'd to that file so it can be uploaded to OCI storage by a later step.
+
+The parent Task must declare the following volumes:
+- a Secret-backed volume for AWS credentials (referenced via `aws-credentials-volume`)
+- an `emptyDir` volume for cluster connection details (referenced via `cluster-info-volume`)
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|aws-credentials-volume|Name of the volume that mounts the AWS credentials secret||true|
+|cluster-info-volume|Name of the volume where mapt will write connection details||true|
+|cluster-info-path|Mount path for the cluster-info volume|/opt/cluster-info|false|
+|id|A unique identifier for this Kind environment||true|
+|arch|Architecture of the instance (`x86_64` or `arm64`)|x86_64|false|
+|cpus|Number of vCPUs to allocate|16|false|
+|memory|Amount of memory in GiB to allocate|64|false|
+|compute-sizes|Comma-separated list of compute sizes (takes precedence over `arch`, `cpus`, `memory`)|""|false|
+|nested-virt|Enables nested virtualization|false|false|
+|spot|Use spot instances|true|false|
+|spot-increase-rate|Percentage added to the base spot price|20|false|
+|spot-eviction-tolerance|Minimum eviction tolerance (`lowest`, `low`, `medium`, `high`, `highest`)|lowest|false|
+|version|Kubernetes version for the Kind cluster|v1.32|false|
+|tags|Additional AWS resource tags. `iac=mapt` and `k8s-type=kind` are added automatically|"''"|false|
+|debug|Enables verbose logging. May expose credentials — use only in secure environments|false|false|
+|timeout|Auto-destroy timeout (e.g. `2h`, `30m`)|"''"|false|
+|extra-port-mappings|Additional port mappings as a JSON array of `{containerPort, hostPort, protocol}` objects|""|false|
+
+## Example Usage
+
+```yaml
+volumes:
+  - name: aws-credentials
+    secret:
+      secretName: $(params.secret-aws-credentials)
+  - name: cluster-info
+    emptyDir: {}
+
+steps:
+  - name: provisioner
+    onError: continue
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/kind-aws-provisioner/0.1/kind-aws-provisioner.yaml
+    params:
+      - name: aws-credentials-volume
+        value: aws-credentials
+      - name: cluster-info-volume
+        value: cluster-info
+      - name: id
+        value: $(params.id)
+```
+
+### Suitable for upstream communities

--- a/stepactions/kind-aws-provisioner/0.1/kind-aws-provisioner.yaml
+++ b/stepactions/kind-aws-provisioner/0.1/kind-aws-provisioner.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: kind-aws-provisioner
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, kind
+    tekton.dev/displayName: "Kind on AWS - Provision"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+    mapt/version: "v0.9.9"
+spec:
+  description: |
+    Provisions a single-node Kind cluster on AWS using the Mapt CLI.
+    Writes connection details (kubeconfig, host, username, id_rsa) to the cluster-info-path directory.
+    If the LOG_FILENAME environment variable is set (e.g. via a Task stepTemplate), output is
+    also tee'd to that file for later OCI log upload.
+  image: quay.io/redhat-developer/mapt:v0.9.9
+  params:
+    - name: aws-credentials-volume
+      type: string
+      description: Name of the volume that mounts the AWS credentials secret.
+    - name: cluster-info-volume
+      type: string
+      description: Name of the volume where mapt will write connection details.
+    - name: cluster-info-path
+      type: string
+      default: '/opt/cluster-info'
+      description: Mount path for the cluster-info volume.
+    - name: id
+      type: string
+      description: A unique identifier for this Kind environment.
+    - name: arch
+      type: string
+      default: 'x86_64'
+      description: Architecture of the instance (x86_64 or arm64).
+    - name: cpus
+      type: string
+      default: '16'
+      description: Number of vCPUs to allocate.
+    - name: memory
+      type: string
+      default: '64'
+      description: Amount of memory in GiB to allocate.
+    - name: compute-sizes
+      type: string
+      default: ''
+      description: |
+        Comma-separated list of compute sizes (e.g. m5a.large,m6a.large).
+        Takes precedence over arch, cpus, and memory when set.
+    - name: nested-virt
+      type: string
+      default: 'false'
+      description: Enables nested virtualization if set to true.
+    - name: spot
+      type: string
+      default: 'true'
+      description: Use spot instances to potentially reduce costs.
+    - name: spot-increase-rate
+      type: string
+      default: '20'
+      description: Percentage added to the base spot price to improve instance acquisition chances.
+    - name: spot-eviction-tolerance
+      type: string
+      default: 'lowest'
+      description: Minimum eviction tolerance level (lowest, low, medium, high, highest).
+    - name: version
+      type: string
+      default: 'v1.32'
+      description: Kubernetes version for the Kind cluster.
+    - name: tags
+      type: string
+      default: ""
+      description: AWS resource tags. iac=mapt and k8s-type=kind are added automatically.
+    - name: debug
+      type: string
+      default: 'false'
+      description: Enables verbose logging. May expose credentials — use only in secure environments.
+    - name: timeout
+      type: string
+      default: ""
+      description: Auto-destroy timeout.
+    - name: extra-port-mappings
+      type: string
+      default: ""
+      description: |
+        Additional port mappings for the Kind cluster as a JSON array of objects with
+        containerPort, hostPort, and protocol properties.
+  volumeMounts:
+    - name: $(params.aws-credentials-volume)
+      mountPath: /opt/aws-credentials
+    - name: $(params.cluster-info-volume)
+      mountPath: $(params.cluster-info-path)
+  computeResources:
+    requests:
+      memory: "200Mi"
+      cpu: "100m"
+    limits:
+      memory: "600Mi"
+      cpu: "300m"
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+    if [[ "$(params.debug)" == "true" ]]; then set -xeuo pipefail; fi
+
+    AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
+    export AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
+    export AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
+    export AWS_DEFAULT_REGION
+    BUCKET=$(cat /opt/aws-credentials/bucket)
+
+    cmd=(mapt aws kind create
+      --project-name "kind-$(params.id)"
+      --backed-url "s3://${BUCKET}/mapt/kind/$(params.id)"
+      --conn-details-output "$(params.cluster-info-path)"
+    )
+    if [[ "$(params.compute-sizes)" != "" ]]; then
+      cmd+=(--compute-sizes "$(params.compute-sizes)")
+    else
+      cmd+=(--arch "$(params.arch)" --cpus "$(params.cpus)" --memory "$(params.memory)")
+    fi
+    if [[ "$(params.extra-port-mappings)" != "" ]]; then
+      cmd+=(--extra-port-mappings "$(params.extra-port-mappings)")
+    fi
+    if [[ "$(params.nested-virt)" == "true" ]]; then cmd+=(--nested-virt); fi
+    if [[ "$(params.version)" != "" ]]; then cmd+=(--version "$(params.version)"); fi
+    if [[ "$(params.spot)" == "true" ]]; then
+      cmd+=(--spot --spot-increase-rate "$(params.spot-increase-rate)" --spot-eviction-tolerance "$(params.spot-eviction-tolerance)")
+    fi
+    if [[ "$(params.timeout)" != "" ]]; then cmd+=(--timeout "$(params.timeout)"); fi
+    tags_value="iac=mapt,k8s-type=kind,cluster-name=$(params.id)"
+    if [[ "$(params.tags)" != "" ]]; then
+      tags_value="${tags_value},$(params.tags)"
+    fi
+    cmd+=(--tags "${tags_value}")
+
+    if [[ -n "${LOG_FILENAME:-}" ]]; then
+      "${cmd[@]}" 2>&1 | tee "$LOG_FILENAME"
+      exit_code="${PIPESTATUS[0]}"
+    else
+      "${cmd[@]}"
+      exit_code="$?"
+    fi
+    echo "[INFO] cluster provisioning finished with exit code $exit_code"
+    exit "$exit_code"

--- a/stepactions/update-kubeconfig-secret/0.1/README.md
+++ b/stepactions/update-kubeconfig-secret/0.1/README.md
@@ -1,0 +1,43 @@
+# update-kubeconfig-secret stepaction
+
+Patches an existing Kubernetes Secret with the `kubeconfig` file found in the cluster-info
+directory. The file is base64-encoded before patching. Typically used after `kind-aws-provisioner`
+to populate the secret that was pre-created by `create-kubeconfig-secret`.
+
+The parent Task must declare the `emptyDir` volume referenced by `cluster-info-volume` and
+share it with the provisioner step that writes the kubeconfig.
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|secret-name|The name of the Kubernetes Secret to update||true|
+|namespace|The namespace of the Secret||true|
+|cluster-info-volume|Name of the volume containing the kubeconfig file||true|
+|cluster-info-path|Mount path for the cluster-info volume|/opt/cluster-info|false|
+
+## Example Usage
+
+```yaml
+steps:
+  - name: update-kubeconfig-secret
+    onError: continue
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/update-kubeconfig-secret/0.1/update-kubeconfig-secret.yaml
+    params:
+      - name: secret-name
+        value: $(params.cluster-access-secret-name)
+      - name: namespace
+        value: $(context.taskRun.namespace)
+      - name: cluster-info-volume
+        value: cluster-info
+```
+
+### Suitable for upstream communities

--- a/stepactions/update-kubeconfig-secret/0.1/update-kubeconfig-secret.yaml
+++ b/stepactions/update-kubeconfig-secret/0.1/update-kubeconfig-secret.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: update-kubeconfig-secret
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, kubernetes
+    tekton.dev/displayName: "Update Kubeconfig Secret"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    Patches an existing Kubernetes Secret with the kubeconfig file found in the
+    cluster-info directory. The kubeconfig is base64-encoded before patching.
+  image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+  params:
+    - name: secret-name
+      type: string
+      description: The name of the Kubernetes Secret to update with the kubeconfig.
+    - name: namespace
+      type: string
+      description: The namespace of the Secret.
+    - name: cluster-info-volume
+      type: string
+      description: Name of the volume containing the kubeconfig file.
+    - name: cluster-info-path
+      type: string
+      default: '/opt/cluster-info'
+      description: Mount path for the cluster-info volume.
+  volumeMounts:
+    - name: $(params.cluster-info-volume)
+      mountPath: $(params.cluster-info-path)
+  env:
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: KUBECONFIG_SECRET_NAME
+      value: $(params.secret-name)
+    - name: CLUSTER_INFO_PATH
+      value: $(params.cluster-info-path)
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+
+    KUBECONFIG_B64=$(base64 -w0 < "${CLUSTER_INFO_PATH}/kubeconfig")
+    patch_payload=$(printf '{"data":{"kubeconfig":"%s"}}' "${KUBECONFIG_B64}")
+
+    oc patch secret "${KUBECONFIG_SECRET_NAME}" -n "${NAMESPACE}" \
+      --type='merge' \
+      -p="${patch_payload}"
+
+    echo "[INFO] Updated secret ${KUBECONFIG_SECRET_NAME} with kubeconfig."

--- a/stepactions/update-ssh-credentials-secret/0.1/README.md
+++ b/stepactions/update-ssh-credentials-secret/0.1/README.md
@@ -1,0 +1,45 @@
+# update-ssh-credentials-secret stepaction
+
+Patches an existing Kubernetes Secret with SSH credentials (`host`, `username`, `id_rsa`) read
+from the cluster-info directory. Each file is base64-encoded before patching. Typically used after
+`kind-aws-provisioner` to populate the secret pre-created by `create-ssh-credentials-secret`.
+
+If `secret-name` is empty, the step exits immediately without making any changes.
+
+The parent Task must declare the `emptyDir` volume referenced by `cluster-info-volume` and
+share it with the provisioner step that writes the SSH credential files.
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|secret-name|The name of the Kubernetes Secret to update. If empty, the step is skipped.|""|false|
+|namespace|The namespace of the Secret||true|
+|cluster-info-volume|Name of the volume containing the SSH credentials files (`host`, `username`, `id_rsa`)||true|
+|cluster-info-path|Mount path for the cluster-info volume|/opt/cluster-info|false|
+
+## Example Usage
+
+```yaml
+steps:
+  - name: update-ssh-credentials-secret
+    onError: continue
+    ref:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/tekton-integration-catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: stepactions/update-ssh-credentials-secret/0.1/update-ssh-credentials-secret.yaml
+    params:
+      - name: secret-name
+        value: $(params.ssh-credentials-secret-name)
+      - name: namespace
+        value: $(context.taskRun.namespace)
+      - name: cluster-info-volume
+        value: cluster-info
+```
+
+### Suitable for upstream communities

--- a/stepactions/update-ssh-credentials-secret/0.1/update-ssh-credentials-secret.yaml
+++ b/stepactions/update-ssh-credentials-secret/0.1/update-ssh-credentials-secret.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: update-ssh-credentials-secret
+  labels:
+    app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, kubernetes
+    tekton.dev/displayName: "Update SSH Credentials Secret"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    Patches an existing Kubernetes Secret with SSH credentials (host, username, id_rsa) read
+    from the cluster-info directory. If secret-name is empty, the step is skipped.
+  image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+  params:
+    - name: secret-name
+      type: string
+      default: ""
+      description: |
+        The name of the Kubernetes Secret to update with SSH credentials.
+        If empty, the step is skipped.
+    - name: namespace
+      type: string
+      description: The namespace of the Secret.
+    - name: cluster-info-volume
+      type: string
+      description: Name of the volume containing the SSH credentials files (host, username, id_rsa).
+    - name: cluster-info-path
+      type: string
+      default: '/opt/cluster-info'
+      description: Mount path for the cluster-info volume.
+  volumeMounts:
+    - name: $(params.cluster-info-volume)
+      mountPath: $(params.cluster-info-path)
+  env:
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: SSH_SECRET_NAME
+      value: $(params.secret-name)
+    - name: CLUSTER_INFO_PATH
+      value: $(params.cluster-info-path)
+  script: |
+    #!/bin/bash
+    set -euo pipefail
+
+    if [[ -z "$SSH_SECRET_NAME" ]]; then
+      echo "[INFO] No SSH credentials secret requested, skipping update."
+      exit 0
+    fi
+
+    HOST=$(base64 -w0 < "${CLUSTER_INFO_PATH}/host")
+    USERNAME=$(base64 -w0 < "${CLUSTER_INFO_PATH}/username")
+    ID_RSA=$(base64 -w0 < "${CLUSTER_INFO_PATH}/id_rsa")
+
+    patch_payload=$(printf '{"data":{"host":"%s","username":"%s","id_rsa":"%s"}}' \
+      "${HOST}" "${USERNAME}" "${ID_RSA}")
+
+    oc patch secret "${SSH_SECRET_NAME}" -n "${NAMESPACE}" \
+      --type='merge' \
+      -p="${patch_payload}"
+
+    echo "[INFO] Updated secret ${SSH_SECRET_NAME} with SSH credentials."

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/MIGRATION.md
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/MIGRATION.md
@@ -1,0 +1,16 @@
+# Migration from 0.1 to 0.2
+
+The `destroy` inline step has been extracted into a standalone StepAction,
+making it independently reusable and composable. The task interface (params, volumes)
+is unchanged.
+
+## What changed
+
+| Step | StepAction |
+|---|---|
+| `destroy` | `stepactions/kind-aws-destroy/0.1` |
+
+## Action from users
+
+Update the `pathInRepo` reference from `deprovision/0.1/kind-aws-deprovision.yaml` to
+`deprovision/0.2/kind-aws-deprovision.yaml`. No parameter changes are required.

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/Readme.md
@@ -1,0 +1,156 @@
+
+# 🚀 Tekton Task: `kind-aws-deprovision`
+
+**Version:** 0.2
+
+Safely deprovision a Kind cluster on AWS that was previously created using the [`kind-aws-provision`](../../provision/0.3/kind-aws-provision.yaml) task.
+
+---
+
+## 📘 Overview
+
+This task uses the [Mapt CLI](https://github.com/redhat-developer/mapt) to tear down infrastructure created for ephemeral Kubernetes clusters.
+
+In addition to the basic teardown, it can optionally:
+
+- Retrieve and use the cluster’s `kubeconfig`
+- Collect artifacts from the cluster (logs, metrics)
+- Push collected artifacts to an OCI-compliant registry
+
+### Key Features
+
+- Safe and scoped cluster destruction based on a unique ID
+- Uses AWS credentials from a Kubernetes Secret
+- Supports debug mode for troubleshooting
+- Artifact collection and optional registry upload
+
+---
+
+## 🔧 Parameters
+
+| Name                      | Description                                                                                      | Default              | Required |
+|---------------------------|--------------------------------------------------------------------------------------------------|----------------------|----------|
+| `secret-aws-credentials`  | Kubernetes Secret name containing AWS credentials (`access-key`, `secret-key`, etc.)            | —                    | ✅        |
+| `id`                      | Unique identifier for the Kind cluster environment to destroy                                   | —                    | ✅        |
+| `debug`                   | Enable verbose output (prints sensitive info, use with caution)                                 | `false`              | ❌        |
+| `force-destroy`           | Destroy even if there is a provisioning lock on the stack                                       | `true`               | ❌        |
+| `pipeline-aggregate-status` | Status of the overall pipeline run (e.g., Succeeded, Failed). Used for conditional logic.    | `None`               | ❌        |
+| `cluster-access-secret`   | Name of the Kubernetes Secret containing the base64-encoded kubeconfig                           | —                    | ✅        |
+| `oci-container`           | ORAS-compliant OCI registry reference where collected artifacts will be pushed                  | —                    | ✅        |
+| `oci-credentials`         | Name of the secret containing the `oci-storage-dockerconfigjson` key with registry credentials  | `konflux-test-infra` | ✅        |
+
+---
+
+## 🪄 Steps Breakdown
+
+### ✅ Step: `gather-cluster-resources`
+
+If the pipeline did not succeed, this step gathers logs and system artifacts from the cluster using the kubeconfig mounted from `cluster-access-secret`.
+
+### ✅ Step: `secure-push-oci`
+
+Pushes the collected artifacts to the provided OCI registry for archiving or debugging.
+
+### ✅ Step: `destroy`
+
+Uses the Mapt CLI to destroy the Kind cluster based on the provided environment ID.
+
+---
+
+## 🔐 Required Secrets
+
+This task requires several Kubernetes Secrets to operate. Below are the expected formats and required keys:
+
+### 🔑 `secret-aws-credentials`
+
+Holds AWS credentials used by the Mapt CLI for deprovisioning.
+
+**Required keys:**
+
+- `access-key`
+- `secret-key`
+- `region`
+- `bucket`
+
+**Example:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+  namespace: default
+type: Opaque
+data:
+  access-key: <BASE64_ENCODED_AWS_ACCESS_KEY>
+  secret-key: <BASE64_ENCODED_AWS_SECRET_KEY>
+  region: <BASE64_ENCODED_AWS_REGION>
+  bucket: <BASE64_ENCODED_BUCKET_NAME>
+```
+
+---
+
+### 🔑 `cluster-access-secret`
+
+Provides the `kubeconfig` needed to connect to the Kind cluster. This secret is being created by [kind-aws-provision](../../provision/0.3/kind-aws-provision.yaml).
+
+**Required key:**
+
+- `kubeconfig`
+
+**Example:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-access
+  namespace: default
+type: Opaque
+data:
+  kubeconfig: <BASE64_ENCODED_KUBECONFIG>
+```
+
+---
+
+### 🔑 `oci-credentials`
+
+Used for authentication when pushing cluster artifacts to an OCI registry.
+
+> ⚠️ **IMPORTANT:** The key **must** be named `oci-storage-dockerconfigjson`.
+> If the key is missing or misnamed, the task will fail with an error such as:
+> *failed to decode config file at /home/tool-box/.docker/config.json: invalid config format: read /home/tool-box/.docker/config.json: is a directory*
+
+**Required key:**
+
+- `oci-storage-dockerconfigjson`
+
+**Example:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example
+  namespace: sample-tenant
+type: Opaque
+data:
+  oci-storage-dockerconfigjson: <BASE64_ENCODED_DOCKERCONFIGJSON>
+```
+
+Ensure this is a properly formatted `.dockerconfigjson` file and base64-encoded.
+
+---
+
+## ✅ Requirements
+
+- Tekton Pipelines v0.44.x or newer
+- Kubernetes Secret with valid AWS credentials
+
+---
+
+## ⚠️ Notes
+
+- **Graceful Failures**: Most steps have `onError: continue`, which ensures that even in failed pipelines, diagnostics can be gathered before final cleanup.
+
+### Suitable for upstream communities

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/kind-aws-deprovision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.2/kind-aws-deprovision.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: kind-aws-deprovision
+  labels:
+    app.kubernetes.io/version: "0.2"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, kind
+    tekton.dev/displayName: "Kind Cloud Single Node - Destroy"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+    mapt/version: "v0.9.9"
+spec:
+  description: |
+    Tears down a Kind cluster that was previously provisioned on AWS using the Mapt CLI.
+
+    This task is designed to safely and efficiently clean up cloud infrastructure created for ephemeral Kubernetes environments,
+    typically used in CI/CD pipelines or short-lived testing environments.
+
+    It ensures the following:
+    - Proper AWS credentials are used to authenticate the delete operation
+    - Cleanup is scoped to a specific environment ID to avoid accidental deletions
+    - Works seamlessly with previous `kind-aws-provision` task executions
+    - Supports a `debug` mode to enable verbose output for troubleshooting. !!WARNING!! Using debug mode can expose credentials.
+
+    Use this task in any workflow where you want to ensure that your test environments don't linger and incur unnecessary cloud costs.
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)
+    - name: workdir
+      emptyDir: {}
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: $(params.oci-credentials)
+    - name: credentials-volume
+      secret:
+        secretName: $(params.cluster-access-secret)
+
+  stepTemplate:
+    env:
+      - name: KUBECONFIG
+        value: '/credentials/kubeconfig'
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: credentials-volume
+        mountPath: /credentials
+
+  params:
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the aws credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+    - name: id
+      description: |
+        A unique identifier for the Kind environment you want to destroy. This must match the ID used during creation.
+    - name: debug
+      description: |
+        If set to `true`, enables verbose output and displays command execution details.
+        Use only in secure environments as it may expose sensitive credentials.
+      default: 'false'
+    - name: pipeline-aggregate-status
+      type: string
+      description: |
+        The status of the pipeline (e.g., Succeeded, Failed, Completed, None).
+      default: None
+    - name: cluster-access-secret
+      type: string
+      description: |
+        The name of the secret containing the kubeconfig to access the target cluster.
+    - name: oci-container
+      type: string
+      description: |
+        The ORAS container registry URI where artifacts will be stored.
+    - name: oci-credentials
+      type: string
+      description: |
+        The registry secrets where artifacts will be stored.
+    - name: force-destroy
+      type: string
+      description: |
+        If force-destroy is set the command will destroy even if there is a lock when is still provisioning a stack.
+      default: "true"
+
+  steps:
+    - name: gather-cluster-resources
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+      params:
+        - name: credentials
+          value: 'credentials-volume'
+        - name: kubeconfig
+          value: 'kubeconfig'
+        - name: artifact-dir
+          value: '/workspace/konflux-artifacts'
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+
+    - name: secure-push-oci
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace
+        - name: oci-ref
+          value: $(params.oci-container)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+
+    - name: destroy
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/kind-aws-destroy/0.1/kind-aws-destroy.yaml
+      params:
+        - name: aws-credentials-volume
+          value: aws-credentials
+        - name: id
+          value: $(params.id)
+        - name: debug
+          value: $(params.debug)
+        - name: force-destroy
+          value: $(params.force-destroy)

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.3/MIGRATION.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.3/MIGRATION.md
@@ -1,0 +1,27 @@
+# Migration from 0.2 to 0.3
+
+The implementation of every inline step has been extracted into a standalone StepAction,
+making each step independently reusable and composable. The task interface (params, results,
+volumes) is unchanged.
+
+## What changed
+
+All five previously inline steps now delegate to StepActions via `resolver: git`:
+
+| Step | StepAction |
+|---|---|
+| `create-kubeconfig-secret` | `stepactions/create-kubeconfig-secret/0.1` |
+| `create-ssh-credentials-secret` | `stepactions/create-ssh-credentials-secret/0.1` |
+| `provisioner` | `stepactions/kind-aws-provisioner/0.1` |
+| `update-kubeconfig-secret` | `stepactions/update-kubeconfig-secret/0.1` |
+| `update-ssh-credentials-secret` | `stepactions/update-ssh-credentials-secret/0.1` |
+
+> **Note:** `protect-control-plane` was already a StepAction reference in 0.2 and is unchanged.
+
+Task results are now populated via `value: $(steps.<step-name>.results.secret-name)`
+instead of each step writing directly to `$(results.<name>.path)`.
+
+## Action from users
+
+Update the `pathInRepo` reference from `provision/0.2/kind-aws-provision.yaml` to
+`provision/0.3/kind-aws-provision.yaml`. No parameter or result changes are required.

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.3/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.3/Readme.md
@@ -1,0 +1,183 @@
+
+# 🚀 Tekton Task: `kind-aws-provision`
+
+**Version:** 0.3
+
+Create a Kind (Kubernetes in Docker) cluster on AWS using the [Mapt CLI](https://github.com/redhat-developer/mapt).
+This task is ideal for managing **ephemeral clusters** in Tekton-based CI/CD workflows.
+
+---
+
+## ✅ Requirements
+
+- Tekton Pipelines v0.44.x or newer
+- Valid AWS credentials stored as a Kubernetes Secret named "konflux-test-infra"
+
+---
+
+## 📘 Overview
+
+This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outputs a `kubeconfig` as a Kubernetes Secret for use in later pipeline steps. Optionally, it can also create a Secret with SSH credentials (host, username, id_rsa) for the provisioned VM.
+
+### Supported Features
+
+- Spot instance provisioning for cost savings
+- Nested virtualization support
+- Customizable CPU, memory, and architecture
+- Optional timeout for auto-destroy
+- Owner-referenced Secret creation for lifecycle management
+- Optional SSH credentials Secret (host, username, id_rsa) for VM access
+
+---
+
+## 🔧 Parameters
+
+| Name                          | Description                                                                 | Default     | Required |
+|-------------------------------|-----------------------------------------------------------------------------|-------------|----------|
+| `secret-aws-credentials`      | Kubernetes Secret with AWS credentials (`access-key`, `secret-key`, etc.)  | —           | ✅       |
+| `id`                          | Unique identifier for the Kind cluster environment                         | —           | ✅       |
+| `cluster-access-secret-name` | Optional: name for the output kubeconfig Secret                             | `''`        | ❌       |
+| `ssh-credentials-secret-name`| Optional: name for the Secret that will store SSH credentials (host, username, id_rsa) for the created VM. If empty, no SSH credentials secret is created. | `''`        | ❌       |
+| `ownerKind`                   | Type of resource owning the Secret (`PipelineRun`, `TaskRun`)               | `PipelineRun`| ❌       |
+| `ownerName`                   | Name of the owning resource                                                 | —           | ✅       |
+| `ownerUid`                    | UID of the owning resource                                                  | —           | ✅       |
+| `arch`                        | Instance architecture (`x86_64`, `arm64`)                                   | `x86_64`    | ❌       |
+| `cpus`                        | Number of vCPUs to provision                                                | `16`        | ❌       |
+| `memory`                      | Memory in GiB                                                               | `64`        | ❌       |
+| `compute-sizes`               | Comma-separated list of compute sizes, e.g.: `m5a.large,m6a.large` (takes presendence over `arch`, `cpus` and `memory`) | —           | ❌       |
+| `nested-virt`                 | Enable nested virtualization                                                | `false`     | ❌       |
+| `spot`                        | Use spot instances                                                          | `true`      | ❌       |
+| `spot-increase-rate`         | % increase on spot price to improve instance allocation                     | `20`        | ❌       |
+| `spot-eviction-tolerance`    | Minimum spot eviction tolerance (`lowest`, `low`, `medium`, `high`, `highest`) | `lowest` | ❌       |
+| `version`                     | Kubernetes version                                                          | `v1.32`     | ❌       |
+| `tags`                        | description: AWS resource tags. Tags iac=mapt, k8s-type=kind and cluster-name=$(params.id) are added automatically. | `''`        | ❌       |
+| `debug`                       | Enable verbose output (prints credentials; use with caution)               | `false`     | ❌       |
+| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `''`        | ❌       |
+| `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
+| `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored. The secret should contain `data.oci-storage-dockerconfigjson: <dockerconfigjson-content>` | -    | ✅       |
+| `extra-port-mappings`             | Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties. Example: '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}, {\"containerPort\":30013,\"hostPort\":8280,\"protocol\":\"TCP\"}]'  | `''`    | ❌       |
+| `harden-control-plane`       | Enable control-plane hardening (increased resource limits). Recommended only for machines with >= 32 vCPUs and >= 64 GiB RAM. | `false` | ❌       |
+
+---
+
+## 📤 Results
+
+| Result                    | Description                                                                 |
+|---------------------------|-----------------------------------------------------------------------------|
+| `cluster-access-secret`   | Name of the generated Kubernetes Secret containing kubeconfig               |
+| `ssh-credentials-secret`  | Name of the Secret containing SSH credentials (host, username, id_rsa). Empty if not requested. |
+
+### Example output Secret (kubeconfig)
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <generated-or-specified-name>
+type: Opaque
+data:
+  kubeconfig: <base64-encoded>
+```
+
+### Example output Secret (SSH credentials)
+
+When `ssh-credentials-secret-name` is set, the task creates/updates a Secret with the VM SSH access data:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <specified-name>
+type: Opaque
+data:
+  host: <base64-encoded>
+  username: <base64-encoded>
+  id_rsa: <base64-encoded>
+```
+
+---
+
+## 🔐 AWS Credentials Secret Format
+
+Create a Kubernetes Secret like this:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-my-creds
+type: Opaque
+data:
+  access-key: <base64>
+  secret-key: <base64>
+  region: <base64>
+  bucket: <base64>
+```
+
+---
+
+## 📦 Example: How to Use the Kubeconfig in Another Task
+
+After provisioning the cluster, you can make the generated `kubeconfig` available to all task steps by directly mounting the Secret containing it.
+**Use a `stepTemplate` and a Secret-based volume to simplify kubeconfig access.**
+
+### ✅ Recommended Configuration
+
+```yaml
+volumes:
+  - name: credentials
+    secret:
+      secretName: $(params.cluster-access-secret)
+
+stepTemplate:
+  env:
+    - name: KUBECONFIG
+      value: "/credentials/kubeconfig"
+  volumeMounts:
+    - name: credentials
+      mountPath: /credentials
+```
+
+### 💡 Benefits
+
+- Automatically sets the `KUBECONFIG` environment variable for every step.
+- No need to manually decode or copy the kubeconfig.
+- Compatible with CLI tools like `kubectl`, `helm`, etc.
+
+---
+
+## 🔐 Permissions Note
+
+The **ServiceAccount** (used to run the `Konflux PipelineRun`) must have RBAC permissions to manage Secrets in the namespace where the `cluster-access-secret` will be created. These permissions are required to dynamically create and manage the kubeconfig Secret for testing in Ephemeral Clusters.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-kind-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "patch"]
+```
+
+Bind this role to your pipeline's ServiceAccount with a `RoleBinding`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-secret-manager-binding
+subjects:
+  - kind: ServiceAccount
+    name: <your-service-account>
+    namespace: <namespace>
+roleRef:
+  kind: Role
+  name: tekton-secret-manager
+  apiGroup: rbac.authorization.k8s.io
+```
+
+> **Note:** Without these permissions, the task will fail when attempting to create the kubeconfig Secret.
+
+### Suitable for upstream communities

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.3/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.3/kind-aws-provision.yaml
@@ -1,0 +1,350 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: kind-aws-provision
+  labels:
+    app.kubernetes.io/version: "0.3"
+    upstream-usable: "true"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, kind
+    tekton.dev/displayName: "Kind Cloud Single Node - Create"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+    mapt/version: "v0.9.9"
+spec:
+  description: |
+    Creates a single-node Kubernetes cluster using Kind on AWS, powered by the Mapt CLI.
+    This task is ideal for setting up ephemeral clusters for testing or CI/CD workflows.
+
+    It supports:
+      - Spot instance provisioning and nested virtualization
+      - Custom CPU, memory, and architecture configurations
+      - Automatic cluster cleanup via timeout
+      - Securely exposes the generated kubeconfig as a Kubernetes Secret
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)
+    - name: cluster-info
+      emptyDir: {}
+    - name: logs
+      emptyDir: {}
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: $(params.oci-credentials)
+
+  params:
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the aws credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+    - name: id
+      description: A unique identifier for this Kind environment
+    - name: cluster-access-secret-name
+      type: string
+      default: $(context.pipelineRun.name)
+      description: |
+        (Optional) The name to assign to the Kubernetes Secret that will store
+        the kubeconfig for the created cluster. If not specified, a name will be auto-generated.
+    - name: ssh-credentials-secret-name
+      type: string
+      default: ""
+      description: |
+        (Optional) The name to assign to the Kubernetes Secret that will store
+        the SSH credentials (host, username, id_rsa) for the created VM.
+        If left empty, no SSH credentials secret will be created.
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: |
+        The type of Tekton resource (e.g., PipelineRun or TaskRun) that should own the kubeconfig Secret.
+        Deleting this owner will also delete the Secret automatically.
+    - name: ownerName
+      type: string
+      description: |
+        The name of the PipelineRun or TaskRun that owns the resources.
+    - name: ownerUid
+      type: string
+      description: |
+        The UID of the PipelineRun or TaskRun that owns the resources. This ensures proper cleanup.
+    - name: arch
+      description: |
+        The architecture of the instance to launch. Choose between `x86_64` or `arm64`.
+      default: 'x86_64'
+    - name: cpus
+      description: |
+        The number of vCPUs to allocate to the virtual machine.
+      default: '16'
+    - name: memory
+      description: |
+        The amount of memory (in GiB) to allocate to the virtual machine.
+      default: '64'
+    - name: compute-sizes
+      description: |
+        Comma-separated list of compute sizes, e.g.: `m5a.large,m6a.large` (takes presendence over `arch`, `cpus` and `memory`)
+      default: ''
+    - name: nested-virt
+      description: |
+        Enables nested virtualization if set to `true`. Useful for running Kind inside a VM.
+      default: 'false'
+    - name: spot
+      description: |
+        Use spot instances to potentially reduce costs. Set to `true` to enable.
+      default: 'true'
+    - name: spot-increase-rate
+      description: |
+        Adds a percentage to the base spot price to improve chances of getting the instance.
+      default: '20'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
+    - name: version
+      description: |
+        The desired Kubernetes version for the Kind cluster. If left blank, the latest stable version will be used.
+      default: 'v1.32'
+    - name: tags
+      description: AWS resource tags. Tags iac=mapt and k8s-type=kind are added automatically.
+      default: ""
+    - name: debug
+      description: |
+        Enables verbose logging and prints sensitive data like credentials.
+        Only use this for debugging in secure environments.
+      default: 'false'
+    - name: timeout
+      description: Auto-destroy timeout
+      default: ""
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag. It's used for storing logs from the Task's Steps
+    - name: oci-credentials
+      type: string
+      description: |
+        The secret name containing credentials for container registry where the artifacts will be stored.
+        The secret should contain `data.oci-storage-dockerconfigjson: <dockerconfigjson-content>`
+      default: "konflux-test-infra"
+    - name: extra-port-mappings
+      type: string
+      description: |
+        Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties.
+        Example: '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}, {\"containerPort\":30013,\"hostPort\":8280,\"protocol\":\"TCP\"}]'
+      default: ""
+
+    - name: harden-control-plane
+      type: string
+      description: |
+        Enable control-plane hardening for the Kind cluster.
+        When set to `true`, the provisioned cluster's scheduler, controller-manager,
+        apiserver and etcd are patched with increased resource limits and tuned flags
+        suitable for burst E2E workloads.
+
+        **Important:** This is only recommended for big machines (>= 32 vCPUs, >= 64 GiB RAM).
+        Enabling it on smaller instances will over-commit resources and destabilize the cluster.
+      default: 'false'
+
+  results:
+    - name: cluster-access-secret
+      description: Secret with kubeconfig
+      value: $(steps.create-kubeconfig-secret.results.secret-name)
+    - name: ssh-credentials-secret
+      description: Secret with SSH credentials (host, username, id_rsa). Empty if not requested.
+      value: $(steps.create-ssh-credentials-secret.results.secret-name)
+
+  stepTemplate:
+    env:
+      - name: LOG_FILENAME
+        value: '/var/log-dir/kind-aws-provision.log'
+    volumeMounts:
+      - name: logs
+        mountPath: /var/log-dir
+
+  steps:
+    - name: create-kubeconfig-secret
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/create-kubeconfig-secret/0.1/create-kubeconfig-secret.yaml
+      params:
+        - name: secret-name
+          value: $(params.cluster-access-secret-name)
+        - name: namespace
+          value: $(context.taskRun.namespace)
+        - name: ownerKind
+          value: $(params.ownerKind)
+        - name: ownerName
+          value: $(params.ownerName)
+        - name: ownerUid
+          value: $(params.ownerUid)
+
+    - name: create-ssh-credentials-secret
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/create-ssh-credentials-secret/0.1/create-ssh-credentials-secret.yaml
+      params:
+        - name: secret-name
+          value: $(params.ssh-credentials-secret-name)
+        - name: namespace
+          value: $(context.taskRun.namespace)
+        - name: ownerKind
+          value: $(params.ownerKind)
+        - name: ownerName
+          value: $(params.ownerName)
+        - name: ownerUid
+          value: $(params.ownerUid)
+
+    - name: provisioner
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/kind-aws-provisioner/0.1/kind-aws-provisioner.yaml
+      params:
+        - name: aws-credentials-volume
+          value: aws-credentials
+        - name: cluster-info-volume
+          value: cluster-info
+        - name: id
+          value: $(params.id)
+        - name: arch
+          value: $(params.arch)
+        - name: cpus
+          value: $(params.cpus)
+        - name: memory
+          value: $(params.memory)
+        - name: compute-sizes
+          value: $(params.compute-sizes)
+        - name: nested-virt
+          value: $(params.nested-virt)
+        - name: spot
+          value: $(params.spot)
+        - name: spot-increase-rate
+          value: $(params.spot-increase-rate)
+        - name: spot-eviction-tolerance
+          value: $(params.spot-eviction-tolerance)
+        - name: version
+          value: $(params.version)
+        - name: tags
+          value: $(params.tags)
+        - name: debug
+          value: $(params.debug)
+        - name: timeout
+          value: $(params.timeout)
+        - name: extra-port-mappings
+          value: $(params.extra-port-mappings)
+
+    - name: protect-control-plane
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/protect-control-plane/0.1/protect-control-plane.yaml
+      params:
+        - name: harden-control-plane
+          value: $(params.harden-control-plane)
+        - name: kubeconfig-dir
+          value: /opt/cluster-info
+        - name: kubeconfig-volume-name
+          value: cluster-info
+
+    - name: update-kubeconfig-secret
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/update-kubeconfig-secret/0.1/update-kubeconfig-secret.yaml
+      params:
+        - name: secret-name
+          value: $(params.cluster-access-secret-name)
+        - name: namespace
+          value: $(context.taskRun.namespace)
+        - name: cluster-info-volume
+          value: cluster-info
+
+    - name: update-ssh-credentials-secret
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/update-ssh-credentials-secret/0.1/update-ssh-credentials-secret.yaml
+      params:
+        - name: secret-name
+          value: $(params.ssh-credentials-secret-name)
+        - name: namespace
+          value: $(context.taskRun.namespace)
+        - name: cluster-info-volume
+          value: cluster-info
+
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /var/log-dir
+        - name: oci-ref
+          value: $(params.oci-ref)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
 ## Summary

  - Extracts all five inline steps of `kind-aws-provision` and the single
    inline step of `kind-aws-deprovision` into standalone StepActions,
    each versioned at `0.1`.
  - Introduces `provision/0.3` and `deprovision/0.2` as new task versions
    that compose those StepActions via `resolver: git`. The task interface
    (params, results, volumes) is identical to the previous versions.
  - Original versions (`provision/0.2`, `deprovision/0.1`) are left
    untouched to preserve compatibility for existing consumers.

  ### New StepActions

  | StepAction | Image | Purpose |
  |---|---|---|
  | `create-kubeconfig-secret/0.1` | `ose-cli:4.13` | Creates an empty kubeconfig Secret with an owner reference |
  | `create-ssh-credentials-secret/0.1` | `ose-cli:4.13` | Creates an empty SSH credentials Secret; skips if name is empty |
  | `kind-aws-provisioner/0.1` | `mapt:v0.9.9` | Runs `mapt aws kind create`; respects `$LOG_FILENAME` from the task stepTemplate |
  | `update-kubeconfig-secret/0.1` | `ose-cli:4.13` | Patches an existing Secret with the kubeconfig from the cluster-info volume |
  | `update-ssh-credentials-secret/0.1` | `ose-cli:4.13` | Patches an existing Secret with SSH credentials; skips if name is empty |
  | `kind-aws-destroy/0.1` | `mapt:v0.9.9` | Runs `mapt aws kind destroy` |

  ### Notable implementation details

  - Task results in `provision/0.3` use `value: $(steps.<step>.results.secret-name)`
    to propagate StepAction results rather than writing directly to `$(results.<name>.path)`.
  - `kind-aws-provisioner` checks `${LOG_FILENAME:-}` at runtime so it tees output
    to the log file when invoked from the task (where `stepTemplate` injects it)
    and falls back to stdout when used standalone.
  - Volume names are passed as params to each StepAction following the pattern
    established by `protect-control-plane`.
